### PR TITLE
Detect if user is running as root when reporting failed socket connection

### DIFF
--- a/src/jsd.c
+++ b/src/jsd.c
@@ -80,7 +80,7 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   if (ecx_init(&self->ecx_context, ifname) <= 0) {
     ERROR("Unable to establish socket connection on %s", ifname);
     if(geteuid() == 0) {
-      ERROR("Is the blue box on and connected?");
+      ERROR("Is the device on and connected?");
     } else {
       ERROR("Execute as root");
     }

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -4,6 +4,7 @@
 #include <inttypes.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "jsd/jsd_ati_fts.h"
 #include "jsd/jsd_egd.h"
@@ -77,7 +78,12 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   self->enable_autorecovery = enable_autorecovery;
 
   if (ecx_init(&self->ecx_context, ifname) <= 0) {
-    ERROR("No socket connection on %s. Excecute as root", ifname);
+    ERROR("Unable to establish socket connection on %s", ifname);
+    if(geteuid() == 0) {
+      ERROR("Is the blue box on and connected?");
+    } else {
+      ERROR("Execute as root");
+    }
     return false;
   }
 


### PR DESCRIPTION
If jsd fails to connect to an ethercat device, it suggests that the connection failed because it was not run as `root`

```c
ERROR("No socket connection on %s. Excecute as root", ifname);
```

However there are other reasons why the socket connection may have failed, such as the device not being switched on or improperly configured. On a failed connection, jsd complains about needing root even when the script is being run as root/sudo. 

This update detects if the user is running as root and emits a more helpful error message. 