### PR TITLE
max speed fix

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -783,7 +783,7 @@ int jsd_egd_config_COE_params(ecx_contextt* ecx_context, uint16_t slave_id,
           (void*)&ca_18)) {
     return 0;
   }
-  MSG("EGD[%d] read CA[18] = %lu cnts per rev", slave_id, ca_18);
+  MSG("EGD[%d] read CA[18] = %u cnts per rev", slave_id, ca_18);
 
   double max_motor_speed_rpm = (config->egd.max_motor_speed) / (double)ca_18 * 60.0;
 
@@ -791,7 +791,7 @@ int jsd_egd_config_COE_params(ecx_contextt* ecx_context, uint16_t slave_id,
 
   MSG("EGD[%d] max_motor_speed_rpm = %lf as int: %i", slave_id, 
       max_motor_speed_rpm, 
-      max_motor_speed_rpm_int)
+      max_motor_speed_rpm_int);
 
   if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, 0x6080, 0,
                                   JSD_SDO_DATA_I32,

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -774,9 +774,28 @@ int jsd_egd_config_COE_params(ecx_contextt* ecx_context, uint16_t slave_id,
   }
 
   // set max motor speed
+  //   0x6080 accepts units of RPM and internally converts to 
+  //   counts per second according to CA[18]. Every other speed in in cnts/sec
+  //   so to keep the JSD api consistent perform the adjustment here.
+  uint32_t ca_18;
+  if (!jsd_sdo_get_param_blocking(
+          ecx_context, slave_id, jsd_egd_tlc_to_do("CA"), 18, JSD_SDO_DATA_U32,
+          (void*)&ca_18)) {
+    return 0;
+  }
+  MSG("EGD[%d] read CA[18] = %lu cnts per rev", slave_id, ca_18);
+
+  double max_motor_speed_rpm = (config->egd.max_motor_speed) / (double)ca_18 * 60.0;
+
+  int32_t max_motor_speed_rpm_int = (int32_t)max_motor_speed_rpm;
+
+  MSG("EGD[%d] max_motor_speed_rpm = %lf as int: %i", slave_id, 
+      max_motor_speed_rpm, 
+      max_motor_speed_rpm_int)
+
   if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, 0x6080, 0,
                                   JSD_SDO_DATA_I32,
-                                  (void*)&config->egd.max_motor_speed)) {
+                                  (void*)&max_motor_speed_rpm_int)) {
     return 0;
   }
 

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -230,7 +230,7 @@ typedef struct {
       drive_cmd_mode;  ///< controls which egd commands are supported
 
   // Parameters set via SDO
-  int32_t max_motor_speed;  ///< max speed in cnts/sec, negative disables
+  double  max_motor_speed;  ///< max speed in cnts/sec, negative disables
   int8_t  loop_period_ms;   ///< expected loop period in ms for synch. modes
   double  torque_slope;  ///< amps/sec, converted to 0x6087 using CL[1]. Ignored
                          /// by CS mode


### PR DESCRIPTION
The `0x6080` data object `max motor speed` accepts units of RPM instead of the expected cnts/sec. This conversion to RPM is now being done internally so as to keep the JSD API speeds in cnts/sec.