### PR TITLE
Replaced ssh with https soem remote to remove need for ssh token

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ add_definitions(-DEC_VER2)
 
 include(FetchContent)
 FetchContent_Declare(soem
-  GIT_REPOSITORY git@github.com:OpenEtherCATsociety/SOEM.git
+  GIT_REPOSITORY https://github.com/OpenEtherCATsociety/SOEM.git
     GIT_TAG f9db4f2b23455e83d9871568e3a69ab124e0c1a0
     )
 FetchContent_MakeAvailable(soem)


### PR DESCRIPTION
Replace SOEM remote URL with https so no SSH token needed in downstream projects (e.g. CI)