### PR TITLE
Adds driver for Beckhoff EL3162 analog input

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(jsd-lib STATIC
     jsd_el3104.c
     jsd_el3202.c
     jsd_el3318.c
+    jsd_el3162.c
     )
 
 message(STATUS "SOEM INCLUDE DIRS: ${SOEM_INCLUDE_DIRS}")

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -10,6 +10,7 @@
 #include "jsd/jsd_egd.h"
 #include "jsd/jsd_el2124.h"
 #include "jsd/jsd_el3104.h"
+#include "jsd/jsd_el3162.h"
 #include "jsd/jsd_el3202.h"
 #include "jsd/jsd_el3208.h"
 #include "jsd/jsd_el3318.h"
@@ -478,6 +479,10 @@ bool jsd_init_single_device(jsd_t* self, uint16_t slave_id) {
     }
     case JSD_EL3318_PRODUCT_CODE: {
       return jsd_el3318_init(self, slave_id);
+      break;
+    }
+    case JSD_EL3162_PRODUCT_CODE: {
+      return jsd_el3162_init(self, slave_id);
       break;
     }
     default:

--- a/src/jsd_el3162.c
+++ b/src/jsd_el3162.c
@@ -1,0 +1,121 @@
+#include "jsd/jsd_el3162.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include "jsd/jsd_sdo.h"
+
+/****************************************************
+ * Public functions
+ ****************************************************/
+
+const jsd_el3162_state_t* jsd_el3162_get_state(jsd_t* self, uint16_t slave_id) {
+  assert(self);
+  assert(self->ecx_context.slavelist[slave_id].eep_id ==
+         JSD_EL3162_PRODUCT_CODE);
+
+  jsd_el3162_state_t* state = &self->slave_states[slave_id].el3162;
+  return state;
+}
+
+void jsd_el3162_read(jsd_t* self, uint16_t slave_id) {
+  assert(self);
+  assert(self->ecx_context.slavelist[slave_id].eep_id ==
+         JSD_EL3162_PRODUCT_CODE);
+
+  jsd_el3162_state_t* state = &self->slave_states[slave_id].el3162;
+
+  const jsd_el3162_txpdo_t* txpdo =
+      (jsd_el3162_txpdo_t*)self->ecx_context.slavelist[slave_id].inputs;
+
+  for (int ch = 0; ch < JSD_EL3162_NUM_CHANNELS; ++ch) {
+    state->adc_value[ch] = txpdo->channel[ch].value;
+
+    // EL3162 has a 0-10V range and a 16-bit integer ADC value:
+    // 1/((10-0)/2^16)=6553.6 discrete levels/V.
+    state->voltage[ch] = (double)state->adc_value[ch] / 6553.6;
+
+    // EL3162 status data is 1-byte long.
+    state->underrange[ch] = (txpdo->channel[ch].flags >> 0) & 0x01;
+    state->overrange[ch]  = (txpdo->channel[ch].flags >> 1) & 0x01;
+    state->error[ch]      = (txpdo->channel[ch].flags >> 6) & 0x01;
+  }
+}
+
+void jsd_el3162_process(jsd_t* self, uint16_t slave_id) {
+  assert(self);
+  assert(self->ecx_context.slavelist[slave_id].eep_id ==
+         JSD_EL3162_PRODUCT_CODE);
+
+  // Iterate through this device's response queue in JSD's context, and check
+  // for errors until all responses are popped.
+  jsd_async_sdo_process_response(self, slave_id);
+}
+
+/****************************************************
+ * Private functions
+ ****************************************************/
+
+bool jsd_el3162_init(jsd_t* self, uint16_t slave_id) {
+  assert(self);
+  assert(self->ecx_context.slavelist[slave_id].eep_id ==
+         JSD_EL3162_PRODUCT_CODE);
+  assert(self->ecx_context.slavelist[slave_id].eep_man ==
+         JSD_BECKHOFF_VENDOR_ID);
+
+  ec_slavet* slaves = self->ecx_context.slavelist;
+  ec_slavet* slave  = &slaves[slave_id];
+
+  slave->PO2SOconfigx = jsd_el3162_PO2SO_config;
+
+  return true;
+}
+
+int jsd_el3162_PO2SO_config(ecx_contextt* ecx_context, uint16_t slave_id) {
+  assert(ecx_context);
+  assert(ecx_context->slavelist[slave_id].eep_id == JSD_EL3162_PRODUCT_CODE);
+
+  // Since this function prototype is forced by SOEM, we have embedded a
+  // reference to jsd.slave_configs within the ecx_context and extract it here.
+  jsd_slave_config_t* slave_configs =
+      (jsd_slave_config_t*)ecx_context->userdata;
+
+  jsd_slave_config_t* config = &slave_configs[slave_id];
+
+  // Reset to factory default.
+  uint32_t reset_word = JSD_BECKHOFF_RESET_WORD;
+  if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, JSD_BECKHOFF_RESET_SDO,
+                                  JSD_BECKHOFF_RESET_SUBIND, JSD_SDO_DATA_U32,
+                                  &reset_word)) {
+    return 0;
+  }
+
+  MSG("Configuring slave no: %u, SII inferred name: %s", slave_id,
+      ecx_context->slavelist[slave_id].name);
+  MSG("\t Configured name: %s", config->name);
+
+  for (int ch = 0; ch < JSD_EL3162_NUM_CHANNELS; ++ch) {
+    // Index for settings is 0x80n0, where n is channel number (e.g. ch2 =
+    // 0x8010).
+    uint32_t sdo_channel_index = 0x8000 + (0x10 * ch);
+
+    // Enable digital filter on read inputs (synchronized with timer inside
+    // terminal).
+    uint8_t enable_filter = 1;
+    if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, sdo_channel_index,
+                                    0x06, JSD_SDO_DATA_U8, &enable_filter)) {
+      return 0;
+    }
+
+    // Set filter option.
+    uint16_t filter_opt =
+        2;  // 1 kHz IIR filter, fastest rate. Refer to el31xxen.pdf, page 202.
+    if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, sdo_channel_index,
+                                    0x15, JSD_SDO_DATA_U16, &filter_opt)) {
+      return 0;
+    }
+  }
+
+  config->PO2SO_success = true;
+  return 1;
+}

--- a/src/jsd_el3162.c
+++ b/src/jsd_el3162.c
@@ -31,9 +31,10 @@ void jsd_el3162_read(jsd_t* self, uint16_t slave_id) {
   for (int ch = 0; ch < JSD_EL3162_NUM_CHANNELS; ++ch) {
     state->adc_value[ch] = txpdo->channel[ch].value;
 
-    // EL3162 has a 0-10V range and a 16-bit integer ADC value:
-    // 1/((10-0)/2^16)=6553.6 discrete levels/V.
-    state->voltage[ch] = (double)state->adc_value[ch] / 6553.6;
+    // EL3162 has a 0-10V range and a 16-bit integer ADC value. The available
+    // discrete values for that range are 0x0000 - 0x7FFF:
+    // 1/((10-0)/(2^16/2-1))=3276.7 discrete levels/V.
+    state->voltage[ch] = (double)state->adc_value[ch] / 3276.7;
 
     // EL3162 status data is 1-byte long.
     state->underrange[ch] = (txpdo->channel[ch].flags >> 0) & 0x01;

--- a/src/jsd_el3162.h
+++ b/src/jsd_el3162.h
@@ -1,0 +1,52 @@
+#ifndef JSD_EL3162_H
+#define JSD_EL3162_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "jsd/jsd.h"
+
+/**
+ * @brief Single channel of TxPDO data struct
+ *
+ * Note: struct order matters and must be packed.
+ */
+typedef struct __attribute__((__packed__)) {
+  uint8_t flags;
+  int16_t value;
+} jsd_el3162_txpdo_channel_t;
+
+/**
+ * @brief TxPDO struct used to read device data in SOEM IOmap
+ *
+ * Note: Struct order matters and must be packed.
+ */
+typedef struct __attribute__((__packed__)) {
+  jsd_el3162_txpdo_channel_t channel[JSD_EL3162_NUM_CHANNELS];
+} jsd_el3162_txpdo_t;
+
+/**
+ * @brief Intializes EL3162 and registers the PO2SO function
+ *
+ * @param self Pointer to JSD context
+ * @param slave_id Index of device on EtherCAT bus
+ * @return true on success, false on failure
+ */
+bool jsd_el3162_init(jsd_t* self, uint16_t slave_id);
+
+/**
+ * @brief Configuration function called by SOEM upon a PreOp to SafeOp state
+ * transition that (re)configures EL3162 device settings
+ *
+ * @param ecx_context SOEM context pointer
+ * @param slave_id Index of device on EtherCAT bus
+ * @return 1 on success, 0 on failure
+ */
+int jsd_el3162_PO2SO_config(ecx_contextt* ecx_context, uint16_t slave_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/jsd_el3162_pub.h
+++ b/src/jsd_el3162_pub.h
@@ -1,0 +1,39 @@
+#ifndef JSD_EL3162_PUB_H
+#define JSD_EL3162_PUB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "jsd/jsd_pub.h"
+
+/**
+ * @brief Read the EL3162 device state
+ *
+ * @param self Pointer to JSD context
+ * @param slave_id Slave ID of EL3162 device
+ * @return Pointer to EL3162 device state
+ */
+const jsd_el3162_state_t* jsd_el3162_get_state(jsd_t* self, uint16_t slave_id);
+
+/**
+ * @brief Converts raw PDO data to state data
+ *
+ * @param self pointer to JSD context
+ * @param slave_id ID of EL3162 device
+ */
+void jsd_el3162_read(jsd_t* self, uint16_t slave_id);
+
+/**
+ * @brief Processes asynchronous SDO responses
+ *
+ * @param self Pointer to JSD context
+ * @param slave_id ID of EL3162 device
+ */
+void jsd_el3162_process(jsd_t* self, uint16_t slave_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/jsd_el3162_types.h
+++ b/src/jsd_el3162_types.h
@@ -1,0 +1,37 @@
+#ifndef JSD_EL3162_TYPES_H
+#define JSD_EL3162_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "jsd/jsd_common_device_types.h"
+
+#define JSD_EL3162_PRODUCT_CODE (uint32_t)0x0c5a3052
+#define JSD_EL3162_NUM_CHANNELS 2
+
+/**
+ * @brief Configuration struct for EL3162 device initialization
+ */
+typedef struct {
+} jsd_el3162_config_t;
+
+/**
+ * @brief Read struct for EL3162 device
+ */
+typedef struct {
+  double  voltage[JSD_EL3162_NUM_CHANNELS];    ///< Analog input data, converted
+  int16_t adc_value[JSD_EL3162_NUM_CHANNELS];  ///< Analog input data, raw
+  uint8_t underrange[JSD_EL3162_NUM_CHANNELS];  ///< True if value below
+                                                ///< measuring range
+  uint8_t
+          overrange[JSD_EL3162_NUM_CHANNELS];  ///< True if measuring range exceeded
+  uint8_t error[JSD_EL3162_NUM_CHANNELS];  ///< True if channel is over or under
+                                           ///< range
+} jsd_el3162_state_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/jsd_types.h
+++ b/src/jsd_types.h
@@ -13,6 +13,7 @@ extern "C" {
 #include "jsd/jsd_egd_types.h"
 #include "jsd/jsd_el2124_types.h"
 #include "jsd/jsd_el3104_types.h"
+#include "jsd/jsd_el3162_types.h"
 #include "jsd/jsd_el3202_types.h"
 #include "jsd/jsd_el3208_types.h"
 #include "jsd/jsd_el3318_types.h"
@@ -35,6 +36,7 @@ typedef struct {
     jsd_el3104_config_t  el3104;
     jsd_el3202_config_t  el3202;
     jsd_el3318_config_t  el3318;
+    jsd_el3162_config_t  el3162;
   };
   bool PO2SO_success;  // reserved for internal use
 
@@ -52,6 +54,7 @@ typedef struct {
     jsd_el3104_state_t      el3104;
     jsd_el3202_state_t      el3202;
     jsd_el3318_state_t      el3318;
+    jsd_el3162_state_t      el3162;
   };
 
   uint16_t num_async_sdo_requests;   // reserved

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,6 +88,11 @@ if(BUILD_JSD_TESTS)
             jsd_test_utils.c)
     target_link_libraries(jsd_el3318_test ${jsd_test_libs})
 
+    add_executable(jsd_el3162_test
+            device/jsd_el3162_test.c
+            jsd_test_utils.c)
+    target_link_libraries(jsd_el3162_test ${jsd_test_libs})
+
     find_program(VALGRIND_EXECUTABLE NAMES valgrind)
     if(VALGRIND_EXECUTABLE)
         set(CTEST_MEMORYCHECK_COMMAND ${VALGRIND_EXECUTABLE})

--- a/test/device/jsd_el3162_test.c
+++ b/test/device/jsd_el3162_test.c
@@ -1,0 +1,97 @@
+#include <assert.h>
+#include <string.h>
+
+#include "jsd/jsd_el3162_pub.h"
+#include "jsd/jsd_el3162_types.h"
+#include "jsd_test_utils.h"
+
+extern bool  quit;
+extern FILE* file;
+uint8_t      slave_id;
+
+void telemetry_header() {
+  if (!file) {
+    return;
+  }
+  for (int i = 0; i < JSD_EL3162_NUM_CHANNELS; ++i) {
+    fprintf(file, "EL3162_ch%d_raw_value, EL3162_ch_%d_volts, ", i, i);
+    fprintf(file, "error_ch%d, underrange_ch%d, overrange_ch%d, ", i, i, i);
+  }
+  fprintf(file, "\n");
+}
+
+void telemetry_data(void* self) {
+  assert(self);
+
+  if (!file) {
+    return;
+  }
+
+  single_device_server_t*   sds   = (single_device_server_t*)self;
+  const jsd_el3162_state_t* state = jsd_el3162_get_state(sds->jsd, slave_id);
+
+  for (int i = 0; i < JSD_EL3162_NUM_CHANNELS; ++i) {
+    fprintf(file, "%i, %lf,", state->adc_value[i], state->voltage[i]);
+    fprintf(file, "%u, %u,", state->error[i], state->underrange[i]);
+    fprintf(file, "%u,", state->overrange[i]);
+  }
+  fprintf(file, "\n");
+  fflush(file);
+}
+
+void print_info(void* self) {
+  assert(self);
+
+  single_device_server_t*   sds   = (single_device_server_t*)self;
+  const jsd_el3162_state_t* state = jsd_el3162_get_state(sds->jsd, slave_id);
+  MSG("Ch0: %f V, Ch1: %f V", state->voltage[0], state->voltage[1]);
+}
+
+void extract_data(void* self) {
+  assert(self);
+
+  single_device_server_t* sds = (single_device_server_t*)self;
+  jsd_el3162_read(sds->jsd, slave_id);
+}
+
+void command(void* self) { (void)self; };
+
+int main(int argc, char* argv[]) {
+  if (argc != 4) {
+    ERROR("Expecting exactly 3 arguments");
+    MSG("Usage: jsd_el3162_test <ifname> <el3162_slave_index> <loop_freq_hz>");
+    MSG("Example: $ jsd_el3162_test eth0 2 1000");
+    return 0;
+  }
+
+  char* ifname          = strdup(argv[1]);
+  slave_id              = atoi(argv[2]);
+  uint32_t loop_freq_hz = atoi(argv[3]);
+  MSG("Configuring device %s, using slave %d", ifname, slave_id);
+  MSG("Using frequency of %i hz", loop_freq_hz);
+
+  single_device_server_t sds;
+
+  sds_set_telemetry_header_callback(&sds, telemetry_header);
+  sds_set_telemetry_data_callback(&sds, telemetry_data);
+  sds_set_print_info_callback(&sds, print_info);
+  sds_set_extract_data_callback(&sds, extract_data);
+  sds_set_command_callback(&sds, command);
+
+  sds_setup(&sds, loop_freq_hz);
+
+  // Set device configuration here.
+  jsd_slave_config_t my_config = {0};
+
+  snprintf(my_config.name, JSD_NAME_LEN, "unicorn");
+  my_config.configuration_active = true;
+  my_config.product_code         = JSD_EL3162_PRODUCT_CODE;
+
+  jsd_set_slave_config(sds.jsd, slave_id, my_config);
+
+  sds_run(&sds, ifname, "/tmp/jsd_el3162.csv");
+
+  free(ifname);
+
+  return 0;
+}


### PR DESCRIPTION
Summary:
Adds the JSD driver for the Beckhoff EL3162 terminal which is a
2-channel analog input for voltage range 0-10 V. Inputs have
reference ground as common ground potential.

Test Plan:
Performed preliminary testing via the written test executable and
the terminal connected to a local EtherCAT network. No inputs were
connected yet.

Reviewers: alex-brinkman, JosephBowkett