### PR TITLE
Adds gain scheduling capabilities to EGD's driver.

### DIFF
--- a/src/jsd_egd_pub.h
+++ b/src/jsd_egd_pub.h
@@ -67,7 +67,29 @@ void jsd_egd_set_digital_output(jsd_t* self, uint16_t slave_id,
                                 uint8_t digital_output_index,
                                 uint8_t output_level);
 
-// Set Manual Gain TODO
+/**
+ * @brief Set the gain scheduling index manually
+ *
+ * Real-time safe
+ * Only available to JSD_EGD_DRIVE_MODE_CMD_CS command mode
+ *
+ * Sets the index of the gain/parameter set for the controller or one of the
+ * filters via Dictionary Object 0x2E00. Two indexes can be selected
+ * independently through the LSB or MSB byte of the object. The GS command
+ * determines which controller or filter is assigned the gains/parameters
+ * specified by the index. See MAN-G-CR, command GS.
+ *
+ * @param self Pointer to JSD context
+ * @param slave_id Slave ID of EGD device
+ * @param lsb_byte Whether the provided index is for the controller/filter
+ * assigned to the LSB (true) or MSB (false) of 0x2E00.
+ * @param gain_scheduling_index Index of the gain/parameter set. It can range
+ * from 1-63, and each value corresponds to a particular set of gains for the
+ * controller or parameters for a filter.
+ */
+void jsd_egd_set_gain_scheduling_index(jsd_t* self, uint16_t slave_id,
+                                       bool     lsb_byte,
+                                       uint16_t gain_scheduling_index);
 
 /**
  * @brief Set drive peak current, PL[1]
@@ -261,6 +283,23 @@ void jsd_egd_async_sdo_set_drive_position(jsd_t* self, uint16_t slave_id,
  */
 void jsd_egd_async_sdo_set_unit_mode(jsd_t* self, uint16_t slave_id,
                                      int32_t mode);
+
+/**
+ * @brief Set the gain scheduling mode for the controller, GS[2]
+ *
+ * Real-time safe, but uses SDO background thread.
+ * See MAN-G-CR for more information.
+ *
+ * It is recommended that the application checks the status of the
+ * async_sdo_in_prog state field before issuing commands that may depend on this
+ * setting (e.g. jsd_egd_set_gain_scheduling_index).
+ *
+ * @param self Pointer to JSD context
+ * @param slave_id Slave ID of EGD device
+ * @param mode Gain scheduling mode
+ */
+void jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+    jsd_t* self, uint16_t slave_id, jsd_egd_gain_scheduling_mode_t mode);
 
 #ifdef __cplusplus
 }

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -136,6 +136,23 @@ typedef enum {
 } jsd_egd_fault_code_t;
 
 /**
+ * @brief Elmo Gold Drive's gain scheduling mode for the controller and filters.
+ *
+ * See MAN-G-CR, command GS[2, 16, 17, 18].
+ *
+ */
+typedef enum {
+  JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED = 0,   ///< No gain scheduling
+  JSD_EGD_GAIN_SCHEDULING_SPEED         = 64,  ///< Scheduling by speed
+  JSD_EGD_GAIN_SCHEDULING_POSITION      = 65,  ///< Scheduling by position
+  JSD_EGD_GAIN_SCHEDULING_SETTLING      = 66,  ///< Scheduling by Best Settling
+  JSD_EGD_GAIN_SCHEDULING_MANUAL_LOW =
+      67,  ///< Manual selection via lower byte of 0x2E00 object
+  JSD_EGD_GAIN_SCHEDULING_MANUAL_HIGH =
+      68,  ///< Manual selection via upper byte of 0x2E00 object
+} jsd_egd_gain_scheduling_mode_t;
+
+/**
  * @brief Elmo Gold Drive Motion Command for Profiled Position Mode of
  * Operation
  *
@@ -335,6 +352,7 @@ typedef struct __attribute__((__packed__)) {
   int16_t  torque_offset;      ///< 0x60B2
   int8_t   mode_of_operation;  ///< 0x6060
   uint16_t max_current;        ///< 0x6073 PL[1]
+  uint16_t gain_scheduling_index;  ///< 0x2E00
 } jsd_egd_rxpdo_data_cs_mode_t;
 
 /**

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -143,12 +143,12 @@ typedef enum {
  */
 typedef enum {
   JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED = 0,   ///< No gain scheduling
-  JSD_EGD_GAIN_SCHEDULING_SPEED         = 64,  ///< Scheduling by speed
-  JSD_EGD_GAIN_SCHEDULING_POSITION      = 65,  ///< Scheduling by position
-  JSD_EGD_GAIN_SCHEDULING_SETTLING      = 66,  ///< Scheduling by Best Settling
-  JSD_EGD_GAIN_SCHEDULING_MANUAL_LOW =
+  JSD_EGD_GAIN_SCHEDULING_MODE_SPEED    = 64,  ///< Scheduling by speed
+  JSD_EGD_GAIN_SCHEDULING_MODE_POSITION = 65,  ///< Scheduling by position
+  JSD_EGD_GAIN_SCHEDULING_MODE_SETTLING = 66,  ///< Scheduling by Best Settling
+  JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW =
       67,  ///< Manual selection via lower byte of 0x2E00 object
-  JSD_EGD_GAIN_SCHEDULING_MANUAL_HIGH =
+  JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_HIGH =
       68,  ///< Manual selection via upper byte of 0x2E00 object
 } jsd_egd_gain_scheduling_mode_t;
 

--- a/src/jsd_sdo.c
+++ b/src/jsd_sdo.c
@@ -102,6 +102,11 @@ static void print_sdo_param(jsd_sdo_data_type_t data_type, uint16_t slave_id,
           data.as_i32);
       break;
 
+    case JSD_SDO_DATA_I64:
+      MSG("Slave[%d] %s 0x%X:%d (I32) = %ld", slave_id, verb, index, subindex,
+          data.as_i64);
+      break;
+
     case JSD_SDO_DATA_FLOAT:
       MSG("Slave[%d] %s 0x%X:%d (F32) = %f", slave_id, verb, index, subindex,
           data.as_float);
@@ -121,6 +126,12 @@ static void print_sdo_param(jsd_sdo_data_type_t data_type, uint16_t slave_id,
       MSG("Slave[%d] %s 0x%X:%d (U32) = %u", slave_id, verb, index, subindex,
           data.as_u32);
       break;
+
+    case JSD_SDO_DATA_U64:
+      MSG("Slave[%d] %s 0x%X:%d (U32) = %lu", slave_id, verb, index, subindex,
+          data.as_u64);
+      break;
+
     default:
       WARNING("Slave[%d] data type unspecified", slave_id);
       break;
@@ -205,6 +216,11 @@ int jsd_sdo_data_type_size(jsd_sdo_data_type_t type) {
     case JSD_SDO_DATA_FLOAT:  // fallthrough intended
     case JSD_SDO_DATA_U32:
       size = 4;
+      break;
+
+    case JSD_SDO_DATA_I64:  // fallthrough intended
+    case JSD_SDO_DATA_U64:
+      size = 8;
       break;
 
     default:

--- a/src/jsd_types.h
+++ b/src/jsd_types.h
@@ -72,10 +72,12 @@ typedef union {
   int8_t   as_i8;
   int16_t  as_i16;
   int32_t  as_i32;
+  int64_t  as_i64;
   float    as_float;
   uint8_t  as_u8;
   uint16_t as_u16;
   uint32_t as_u32;
+  uint64_t as_u64;
 } jsd_sdo_data_t;
 
 typedef enum {
@@ -83,10 +85,12 @@ typedef enum {
   JSD_SDO_DATA_I8,
   JSD_SDO_DATA_I16,
   JSD_SDO_DATA_I32,
+  JSD_SDO_DATA_I64,
   JSD_SDO_DATA_FLOAT,
   JSD_SDO_DATA_U8,
   JSD_SDO_DATA_U16,
   JSD_SDO_DATA_U32,
+  JSD_SDO_DATA_U64,
 } jsd_sdo_data_type_t;
 
 typedef enum {


### PR DESCRIPTION
Summary:
Extends the Elmo Gold Drive's driver to enable the selection of the
gain scheduling strategy for its controller and the selection of
particular gain sets when the strategy is manual scheduling.

Test Plan:
Tested by temporarily modifying test/device/jsd_egd_csp_sine_test.c
to periodically switch between two sets of gains. The switch of
gains was corroborated by watching the behavior of the motor shaft
while tracking position.

Reviewers: alex-brinkman, JosephBowkett