### PR TITLE
Adds gain scheduling config to EGD's driver.

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -951,6 +951,14 @@ int jsd_egd_config_TLC_params(ecx_contextt* ecx_context, uint16_t slave_id,
     return 0;
   }
 
+  int64_t ctrl_gs_mode_i64 = config->egd.ctrl_gain_scheduling_mode;
+  if (ctrl_gs_mode_i64 != -1 &&
+      !jsd_sdo_set_param_blocking(ecx_context, slave_id,
+                                  jsd_egd_tlc_to_do("GS"), 2, JSD_SDO_DATA_I64,
+                                  (void*)&ctrl_gs_mode_i64)) {
+    return 0;
+  }
+
   // set smooth factor
   if (!jsd_sdo_set_param_blocking(ecx_context, slave_id,
                                   jsd_egd_tlc_to_do("SF"), 1, JSD_SDO_DATA_I32,

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -277,6 +277,10 @@ typedef struct {
 
   int32_t smooth_factor;  ///< SF[1] msec, [0, 63] 0 is default
 
+  jsd_egd_gain_scheduling_mode_t
+      ctrl_gain_scheduling_mode;  ///< GS[2]. Set to -1 to use mode saved in
+                                  ///< drive's non-volatile memory.
+
 } jsd_egd_config_t;
 
 /**

--- a/test/device/jsd_egd_csp_sine_test.c
+++ b/test/device/jsd_egd_csp_sine_test.c
@@ -237,6 +237,7 @@ int main(int argc, char* argv[]) {
   my_config.egd.brake_disengage_msec          = BRAKE_TIME_MSEC;
   my_config.egd.crc                           = INT32_MIN;
   my_config.egd.drive_max_current_limit       = -FLT_MAX;
+  my_config.egd.ctrl_gain_scheduling_mode     = -1;
 
   MSG("Configuring %i as loop_period_ms", my_config.egd.loop_period_ms);
 

--- a/test/device/jsd_egd_test.c
+++ b/test/device/jsd_egd_test.c
@@ -197,6 +197,7 @@ int main(int argc, char* argv[]) {
   my_config.egd.high_position_limit           = 0;
   my_config.egd.crc                           = INT32_MIN;
   my_config.egd.drive_max_current_limit       = -FLT_MAX;
+  my_config.egd.ctrl_gain_scheduling_mode     = -1;
 
   jsd_set_slave_config(sds.jsd, slave_id, my_config);
 


### PR DESCRIPTION
Summary:
Adds a parameter in the Elmo Gold Drive's driver configuration to
allow setting of controller gain scheduling mode before the EtherCAT
device enters operational mode.

Test Plan:
To be tested on modified version of
test/device/jsd_egd_csp_sine_test.c.

Reviewers: alex-brinkman, JosephBowkett