### PR TITLE
Fixes EGD's gain scheduling config when absent

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -952,7 +952,7 @@ int jsd_egd_config_TLC_params(ecx_contextt* ecx_context, uint16_t slave_id,
   }
 
   int64_t ctrl_gs_mode_i64 = config->egd.ctrl_gain_scheduling_mode;
-  if (ctrl_gs_mode_i64 != -1 &&
+  if (ctrl_gs_mode_i64 != JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED &&
       !jsd_sdo_set_param_blocking(ecx_context, slave_id,
                                   jsd_egd_tlc_to_do("GS"), 2, JSD_SDO_DATA_I64,
                                   (void*)&ctrl_gs_mode_i64)) {

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -142,6 +142,8 @@ typedef enum {
  *
  */
 typedef enum {
+  JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED =
+      -1,  ///< Scheduling mode saved in the drive's non-volatile memory
   JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED = 0,   ///< No gain scheduling
   JSD_EGD_GAIN_SCHEDULING_MODE_SPEED    = 64,  ///< Scheduling by speed
   JSD_EGD_GAIN_SCHEDULING_MODE_POSITION = 65,  ///< Scheduling by position

--- a/test/device/jsd_egd_csp_sine_test.c
+++ b/test/device/jsd_egd_csp_sine_test.c
@@ -237,7 +237,8 @@ int main(int argc, char* argv[]) {
   my_config.egd.brake_disengage_msec          = BRAKE_TIME_MSEC;
   my_config.egd.crc                           = INT32_MIN;
   my_config.egd.drive_max_current_limit       = -FLT_MAX;
-  my_config.egd.ctrl_gain_scheduling_mode     = -1;
+  my_config.egd.ctrl_gain_scheduling_mode =
+      JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED;
 
   MSG("Configuring %i as loop_period_ms", my_config.egd.loop_period_ms);
 

--- a/test/device/jsd_egd_test.c
+++ b/test/device/jsd_egd_test.c
@@ -197,7 +197,8 @@ int main(int argc, char* argv[]) {
   my_config.egd.high_position_limit           = 0;
   my_config.egd.crc                           = INT32_MIN;
   my_config.egd.drive_max_current_limit       = -FLT_MAX;
-  my_config.egd.ctrl_gain_scheduling_mode     = -1;
+  my_config.egd.ctrl_gain_scheduling_mode =
+      JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED;
 
   jsd_set_slave_config(sds.jsd, slave_id, my_config);
 


### PR DESCRIPTION
Summary:
Fixes issue with EGD's gain scheduling mode configuration when the drive's pre-loaded mode is desired. The root of the problem was a type cast issue between an enumeration type and an integer type.

Test Plan:
Tested with fcat and an actual motor. The fcat ROS1 module was modified for this test to support the EGD Fastcat driver.

Reviewers: JosephBowkett, alex-brinkman