### PR TITLE
Quadrupled IO map size for EELS

### DIFF
--- a/src/jsd_include_defs.h
+++ b/src/jsd_include_defs.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stdint.h>
 
 #define JSD_NAME_LEN 64
-#define JSD_IOMAP_BYTES 1024
+#define JSD_IOMAP_BYTES 4096
 
 #define JSD_SDO_TIMEOUT 1.4e6  // usec
 


### PR DESCRIPTION
EELS 27 actuator FastCAT bus ran out of IO map space, and they'll be going as high as 40 actuators.

Smallest multiple of 2 that will cover 40 is 4096, tested working on the 27 actuator robot.