### PR TITLE
Add timestamp to jsd_print.h macros.

### DIFF
--- a/src/jsd_print.h
+++ b/src/jsd_print.h
@@ -5,29 +5,32 @@
 extern "C" {
 #endif
 
+#include <jsd/jsd_time.h>
 #include <stdio.h>
 
 #ifdef DEBUG
-#define MSG_DEBUG(M, ...) \
-  fprintf(stderr, "[ DEBUG ](%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#define MSG_DEBUG(M, ...)                                                     \
+  fprintf(stderr, "[ DEBUG ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
+          __FILE__, __LINE__, ##__VA_ARGS__)
 #else
 #define MSG_DEBUG(M, ...)
 #endif
 
-#define MSG(M, ...) \
-  fprintf(stderr, "[ INFO  ](%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#define MSG(M, ...)                                                           \
+  fprintf(stderr, "[ INFO  ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
+          __FILE__, __LINE__, ##__VA_ARGS__)
 
-#define WARNING(M, ...)                                                  \
-  fprintf(stderr, "\033[1;33m[ WARN  ](%s:%d) " M "\033[0m\n", __FILE__, \
-          __LINE__, ##__VA_ARGS__)
+#define WARNING(M, ...)                                               \
+  fprintf(stderr, "\033[1;33m[ WARN  ] [%lf] (%s:%d) " M "\033[0m\n", \
+          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
 
-#define ERROR(M, ...)                                                    \
-  fprintf(stderr, "\033[1;31m[ ERROR ](%s:%d) " M "\033[0m\n", __FILE__, \
-          __LINE__, ##__VA_ARGS__)
+#define ERROR(M, ...)                                                 \
+  fprintf(stderr, "\033[1;31m[ ERROR ] [%lf] (%s:%d) " M "\033[0m\n", \
+          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
 
-#define SUCCESS(M, ...)                                                  \
-  fprintf(stderr, "\033[1;32m[SUCCESS](%s:%d) " M "\033[0m\n", __FILE__, \
-          __LINE__, ##__VA_ARGS__)
+#define SUCCESS(M, ...)                                               \
+  fprintf(stderr, "\033[1;32m[SUCCESS] [%lf] (%s:%d) " M "\033[0m\n", \
+          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/src/jsd_time.h
+++ b/src/jsd_time.h
@@ -10,7 +10,7 @@ extern "C" {
 
 /**
  * @brief Get the system's clock time since the Unix Epoch.
- * @return Number of seconds isnce Unis Epoch.
+ * @return Number of seconds since Unix Epoch.
  */
 static inline double jsd_time_get_time_sec() {
   struct timeval tv;

--- a/src/jsd_time.h
+++ b/src/jsd_time.h
@@ -1,0 +1,25 @@
+#ifndef JSD_TIME_H_
+#define JSD_TIME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/time.h>
+#include <time.h>
+
+/**
+ * @brief Get the system's clock time since the Unix Epoch.
+ * @return Number of seconds isnce Unis Epoch.
+ */
+static inline double jsd_time_get_time_sec() {
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Adds the system time to the jsd_print.h log messages.
![Screenshot from 2022-07-28 02-38-16](https://user-images.githubusercontent.com/99947029/183584291-dab45b5b-1958-4325-9643-59284a5f163c.png)

