### PR TITLE
fix incorrect header guard

### DIFF
--- a/src/jsd_time.h
+++ b/src/jsd_time.h
@@ -1,5 +1,5 @@
 #ifndef JSD_TIME_H_
-#define JSD_TIME_H
+#define JSD_TIME_H_
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
the `#ifdef` statement used the file name `JSD_TIME_H_` while the `#define` statement used `JSD_TIME_H` which caused a error while building the project