### PR TITLE
Fixes fault code assignment in EGD driver

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -1312,7 +1312,7 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
         ERROR("EMCY: on slave id: %d, Description:  %s", error.Slave,
               jsd_egd_fault_code_to_string(
                   jsd_egd_get_fault_code_from_ec_error(error)));
-        state->pub.fault_code = error.ErrorCode;
+        state->pub.fault_code = jsd_egd_get_fault_code_from_ec_error(error);
       }
 
       set_controlword(self, slave_id,


### PR DESCRIPTION
Summary:
The fault_code variable in the EGD's state was incorrectly assigned the raw Elmo error code instead of the corresponding enumeration value. This has been fixed.

Fixes #32

Reviewers: alex-brinkman, JosephBowkett