### PR TITLE
Alex servo enable plus issue cleanup

### DIFF
--- a/src/jsd.c
+++ b/src/jsd.c
@@ -79,7 +79,6 @@ void jsd_set_slave_config(jsd_t* self, uint16_t slave_id,
   self->slave_configs[slave_id] = slave_config;
 }
 
-// TODO check more of these return status to ensure clean initialization
 bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   assert(self);
   self->enable_autorecovery = enable_autorecovery;
@@ -116,7 +115,6 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
     return false;
   }
   // Print the IOMap input and output pointers for debugging
-  // TODO remove when mature
   int sid;
   for (sid = 1; sid <= *self->ecx_context.slavecount; sid++) {
     MSG_DEBUG(
@@ -146,7 +144,6 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   ecx_configdc(&self->ecx_context);
 
   // Read individual slave state and store in self->ecx_context.slavelist[]
-  // TODO Why?
   ecx_readstate(&self->ecx_context);
 
   self->expected_wkc = (self->ecx_context.grouplist[0].outputsWKC * 2) +

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -1201,7 +1201,7 @@ void jsd_egd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
       state->txpdo.statusword >> 10 & 0x01;  // MAGIC TODO
 
   // Status Register states
-  state->servo_enabled =
+  state->pub.servo_enabled =
       state->txpdo.status_register >> 4 & 0x01;  // MAGIC TODO
   state->fault_occured_when_enabled =
       state->txpdo.status_register >> 6 & 0x01;  // MAGIC TODO

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -561,7 +561,7 @@ bool jsd_egd_init(jsd_t* self, uint16_t slave_id) {
   config->PO2SO_success      = false;  // only set true in PO2SO callback
 
   // Disables Complete Access (CA) in EGD devices
-  // This was needed to make PDO mapping work TODO revisit why
+  // This was needed to make PDO mapping work
   slave->CoEdetails &= ~ECT_COEDET_SDOCA;
 
   slave->PO2SOconfigx = jsd_egd_PO2SO_config;

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -1196,23 +1196,23 @@ void jsd_egd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
   }
   state->last_actual_mode_of_operation = state->pub.actual_mode_of_operation;
 
-  state->pub.warning = state->txpdo.statusword >> 7 & 0x01;  // MAGIC TODO
+  state->pub.warning = state->txpdo.statusword >> 7 & 0x01;
   state->pub.target_reached =
-      state->txpdo.statusword >> 10 & 0x01;  // MAGIC TODO
+      state->txpdo.statusword >> 10 & 0x01;
 
   // Status Register states
   state->pub.servo_enabled =
-      state->txpdo.status_register >> 4 & 0x01;  // MAGIC TODO
+      state->txpdo.status_register >> 4 & 0x01;
   state->fault_occured_when_enabled =
-      state->txpdo.status_register >> 6 & 0x01;  // MAGIC TODO
+      state->txpdo.status_register >> 6 & 0x01;
   state->pub.sto_engaged =
-      !(state->txpdo.status_register >> 14 & 0x01);  // TODO
+      !(state->txpdo.status_register >> 14 & 0x01);
   state->pub.motor_on =
-      state->txpdo.status_register >> 22 & 0x01;  // MAGIC TODO
+      state->txpdo.status_register >> 22 & 0x01;
   state->pub.in_motion =
-      state->txpdo.status_register >> 23 & 0x01;  // MAGIC TODO
+      state->txpdo.status_register >> 23 & 0x01;
   state->pub.hall_state =
-      state->txpdo.status_register >> 24 & 0x07;  // TODO test me
+      state->txpdo.status_register >> 24 & 0x07;
 
   // STO status from status register with smart printing
   if (state->last_sto_engaged != state->pub.sto_engaged) {
@@ -1225,7 +1225,7 @@ void jsd_egd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
   state->last_sto_engaged = state->pub.sto_engaged;
 
   // Digital Inputs
-  state->interlock = state->txpdo.digital_inputs >> 3 & 0x01;  // MAGIC TODO
+  state->interlock = state->txpdo.digital_inputs >> 3 & 0x01;
   int i;
   for (i = 0; i < JSD_EGD_NUM_DIGITAL_INPUTS; ++i) {
     state->pub.digital_inputs[i] =

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -856,9 +856,14 @@ int jsd_egd_config_COE_params(ecx_contextt* ecx_context, uint16_t slave_id,
 
 int jsd_egd_config_TLC_params(ecx_contextt* ecx_context, uint16_t slave_id,
                               jsd_slave_config_t* config) {
+
   if (!jsd_sdo_set_param_blocking(ecx_context, slave_id,
                                   jsd_egd_tlc_to_do("AC"), 1, JSD_SDO_DATA_U32,
                                   (void*)&config->egd.max_profile_accel)) {
+    ERROR("EGD[%d] failed to set AC to %u. AC may have a "
+          " minimum permissible profile around 10 counts, try a higher accel!",
+          slave_id, config->egd.max_profile_accel);
+
     return 0;
   }
 

--- a/src/jsd_egd.h
+++ b/src/jsd_egd.h
@@ -7,7 +7,6 @@ extern "C" {
 
 #include "jsd/jsd_egd_pub.h"
 
-// TODO maybe make this an enum?
 #define JSD_EGD_STATE_MACHINE_STATE_BITMASK (uint16_t)0x6F
 
 /**

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -309,6 +309,7 @@ typedef struct {
   uint8_t sto_engaged;     ///< Safe Torque Off (Estop) status
   uint8_t hall_state;      ///< 3 Hall channels (ABC) in first 3 bits TODO test
   uint8_t in_motion;       ///< if motor is in motion
+  uint8_t servo_enabled;   ///< servo enabled, indicates actual brake status
   uint8_t warning;         ///< from statusword (SW), bit 7
   uint8_t target_reached;  ///< from SW, bit 10 mode dependent
   uint8_t motor_on;        ///< from SW, indicates brake and drive status
@@ -407,7 +408,6 @@ typedef struct {
 
   // Fields parsed data from txpdo data
   uint8_t interlock;  ///< from DINs !(STO status) (firmware >= V1.1.10.7 B00)!
-  uint8_t servo_enabled;               ///< from SR, of limited use
   uint8_t fault_occured_when_enabled;  ///< from SR, of limited use
 
   // Async SDO state

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -130,6 +130,7 @@ typedef enum {
   JSD_EGD_FAULT_GANTRY_SLAVE_DISABLED,
 
   JSD_EGD_FAULT_SDO_ERROR,
+  JSD_EGD_FAULT_SDO_TIMEOUT,
 
   JSD_EGD_FAULT_UNKNOWN,
 
@@ -313,7 +314,8 @@ typedef struct {
   uint8_t warning;         ///< from statusword (SW), bit 7
   uint8_t target_reached;  ///< from SW, bit 10 mode dependent
   uint8_t motor_on;        ///< from SW, indicates brake and drive status
-  jsd_egd_fault_code_t fault_code;  ///< from EMCY, != 0 indicates fault
+  uint16_t fault_code;     ///< raw value from EMCY, != 0 indicates fault
+  jsd_egd_fault_code_t fault_enum; ///< Enum from both EMCY and SDO faults
 
   double   bus_voltage;           ///< bus voltage in volts
   double   analog_input_voltage;  ///< Analog 1 input in volts
@@ -399,6 +401,7 @@ typedef struct {
   uint32_t motor_rated_current;  ///< CL[1] in mA
 
   // user input
+  bool                        new_async_sdo_timeout_error;
   bool                        new_reset;
   bool                        new_halt_command;
   bool                        new_motion_command;

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -307,7 +307,7 @@ typedef struct {
   bool                          async_sdo_in_prog;
 
   uint8_t sto_engaged;     ///< Safe Torque Off (Estop) status
-  uint8_t hall_state;      ///< 3 Hall channels (ABC) in first 3 bits TODO test
+  uint8_t hall_state;      ///< 3 Hall channels (ABC) in first 3 bits
   uint8_t in_motion;       ///< if motor is in motion
   uint8_t servo_enabled;   ///< servo enabled, indicates actual brake status
   uint8_t warning;         ///< from statusword (SW), bit 7


### PR DESCRIPTION
* Exposes `servo_enabled` flag to public API (closes #35)
* Added printout to help with AC settings (closes #12)
* Exposes both `fault_code` and new `fault_enum` state to best describe fault types to downstream apps (closes #32)
* Precheck there is a valid position controller on the drive and emit helpful error messages (closes #19) 

Bump minor version