### PR TITLE
change color formatting for debug and warning messages

### DIFF
--- a/src/jsd_print.h
+++ b/src/jsd_print.h
@@ -8,17 +8,21 @@ extern "C" {
 #include <jsd/jsd_time.h>
 #include <stdio.h>
 
+#define GRAY "\033[0;37m"
+#define BLUE "\033[0;34m"
+#define RESET "\033[0m"
+
 #ifdef DEBUG
 #define MSG_DEBUG(M, ...)                                                     \
-  fprintf(stderr, "[ DEBUG ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
-          __FILE__, __LINE__, ##__VA_ARGS__)
+  fprintf(stderr, "%s[ DEBUG ] [%lf] (%s:%d) " M "%s\n", BLUE, jsd_time_get_time_sec(), \
+          __FILE__, __LINE__, ##__VA_ARGS__, RESET)
 #else
 #define MSG_DEBUG(M, ...)
 #endif
 
 #define MSG(M, ...)                                                           \
-  fprintf(stderr, "[ INFO  ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
-          __FILE__, __LINE__, ##__VA_ARGS__)
+  fprintf(stderr, "%s[ INFO  ] [%lf] (%s:%d) " M "%s\n", GRAY, jsd_time_get_time_sec(), \
+          __FILE__, __LINE__, ##__VA_ARGS__, RESET)
 
 #define WARNING(M, ...)                                               \
   fprintf(stderr, "\033[1;33m[ WARN  ] [%lf] (%s:%d) " M "\033[0m\n", \


### PR DESCRIPTION
add 'gray' color for `MSG/INFO` messages and blue color for `MSG_DEBUG` messages.  
<br/>
![Screen Shot 2022-09-30 at 2 07 31 AM](https://user-images.githubusercontent.com/66138036/193137006-a5c6ed74-2f9a-459e-bec3-1833be929a68.png)
