### PR TITLE
Minor comment update in jsd_egd_types.h

### DIFF
--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -304,10 +304,16 @@ typedef struct {
   uint8_t sto_engaged;     ///< Safe Torque Off (Estop) status
   uint8_t hall_state;      ///< 3 Hall channels (ABC) in first 3 bits
   uint8_t in_motion;       ///< if motor is in motion
-  uint8_t servo_enabled;   ///< servo enabled, indicates actual brake status
+  uint8_t servo_enabled;   ///< Servo enabled (commands can be processed);
+                           ///< indicates actual brake status.
+                           ///< For transition into Operation Enabled state,
+                           ///< servo_enabled is 1 after time to disengage brake
+                           ///< elapses. For a transition into any of the Power
+                           ///< Disabled states, servo_enabled is 0 after time
+                           ///< to engage brake elapses.
   uint8_t warning;         ///< from statusword (SW), bit 7
   uint8_t target_reached;  ///< from SW, bit 10 mode dependent
-  uint8_t motor_on;        ///< from SW, indicates brake and drive status
+  uint8_t motor_on;        ///< Motor enabled (powered)
   jsd_egd_fault_code_t fault_code;  ///< from EMCY, != 0 indicates fault
   uint16_t emcy_error_code;         ///< EMCY code, see DS-301 Section 7.1 
 


### PR DESCRIPTION
Clarified comments on `motor_on` and `servo_enabled` fields in `jsd_egd_state_t`. `motor_on` indicates whether the motor is enabled (i.e. powered), while `servo_on` indicates whether the servo is enabled (i.e. motion commands can be processed) and whether the brake is engaged based on the time to disengage/engage brake parameters.