### PR TITLE
Update jsd_egd_types.h

### DIFF
--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -390,7 +390,6 @@ typedef struct {
   jsd_egd_txpdo_data_t               txpdo;       ///< Raw TxPDO data
   jsd_egd_rxpdo_data_cs_mode_t       rxpdo_cs;    ///< Raw RxPDO data
   jsd_egd_rxpdo_data_profiled_mode_t rxpdo_prof;  ///< Raw RxPDO data
-  int8_t* mode_of_operation;  ///< ptr to active rxdpo mode of op
 
   uint32_t motor_rated_current;  ///< CL[1] in mA
 


### PR DESCRIPTION
Removed `mode_of_operation` field in `jsd_egd_private_state_t` because it is unsed.