### PR TITLE
removed jsd_get_time_sec for jsd_time_get_time_sec

### DIFF
--- a/src/jsd.c
+++ b/src/jsd.c
@@ -376,12 +376,6 @@ char* jsd_ec_state_to_string(ec_state state) {
  * Private functions
  ****************************************************/
 
-double jsd_get_time_sec() {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
-}
-
 bool jsd_init_all_devices(jsd_t* self) {
   assert(self);
 

--- a/src/jsd.h
+++ b/src/jsd.h
@@ -9,12 +9,6 @@ extern "C" {
 
 #define JSD_PO2OP_MAX_ATTEMPTS 3
 
-/** @brief Gets current time in seconds
- *
- *  @return monotonic clock time in seconds
- */
-double jsd_get_time_sec();
-
 /**
  * @brief converts ec_state int to human-readable string
  *

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -53,7 +53,7 @@ const jsd_egd_state_t* jsd_egd_get_state(jsd_t* self, uint16_t slave_id) {
 void jsd_egd_reset(jsd_t* self, uint16_t slave_id) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);
-  double now = jsd_get_time_sec();
+  double now = jsd_time_get_time_sec();
   if ((now - self->slave_states[slave_id].egd.last_reset_time) >
       JSD_EGD_RESET_DERATE_SEC) {
     self->slave_states[slave_id].egd.new_reset       = true;
@@ -1132,7 +1132,7 @@ void jsd_egd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
     if(state->pub.actual_state_machine_state == JSD_EGD_STATE_MACHINE_STATE_FAULT){
       jsd_sdo_signal_emcy_check(self);
       state->new_reset = false; // clear any potentially ongoing reset request
-      state->fault_time = jsd_get_time_sec();
+      state->fault_time = jsd_time_get_time_sec();
     }
 
   }
@@ -1302,7 +1302,7 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
 
           }
         }
-      } else if(jsd_get_time_sec() > (1.0 + state->fault_time) &&
+      } else if(jsd_time_get_time_sec() > (1.0 + state->fault_time) &&
               state->pub.fault_code != JSD_EGD_FAULT_UNKNOWN)
       {
         // If we've been waiting for a long duration, the EMCY is not going to come


### PR DESCRIPTION
Removes `jsd_get_time_sec` and all references that clock. 