### PR TITLE
Adds function to compute monotonic time.

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -53,7 +53,7 @@ const jsd_egd_state_t* jsd_egd_get_state(jsd_t* self, uint16_t slave_id) {
 void jsd_egd_reset(jsd_t* self, uint16_t slave_id) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);
-  double now = jsd_time_get_time_sec();
+  double now = jsd_time_get_mono_time_sec();
   if ((now - self->slave_states[slave_id].egd.last_reset_time) >
       JSD_EGD_RESET_DERATE_SEC) {
     self->slave_states[slave_id].egd.new_reset       = true;
@@ -1132,7 +1132,8 @@ void jsd_egd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
     if(state->pub.actual_state_machine_state == JSD_EGD_STATE_MACHINE_STATE_FAULT){
       jsd_sdo_signal_emcy_check(self);
       state->new_reset = false; // clear any potentially ongoing reset request
-      state->fault_time = jsd_time_get_time_sec();
+      state->fault_real_time = jsd_time_get_time_sec();
+      state->fault_mono_time = jsd_time_get_mono_time_sec();
     }
 
   }
@@ -1195,10 +1196,6 @@ void jsd_egd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
 
   // drive temp
   state->pub.drive_temperature = state->txpdo.drive_temperature_deg_c;
-}
-
-static double ectime_to_double(ec_timet t){
-  return (double)t.sec + (double)(t.usec)*1.0e-6;
 }
 
 void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
@@ -1278,8 +1275,7 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
       if(jsd_error_cirq_pop(error_cirq, &error)) {
 
         // if newer than the state-machine issued fault
-        if(ectime_to_double(error.Time) > state->fault_time){
-
+        if (ectime_to_sec(error.Time) > state->fault_real_time) {
           // TODO consider handling the other error types too
           if(error.Etype == EC_ERR_TYPE_EMERGENCY){
             state->pub.emcy_error_code = error.ErrorCode;
@@ -1302,9 +1298,9 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
 
           }
         }
-      } else if(jsd_time_get_time_sec() > (1.0 + state->fault_time) &&
-              state->pub.fault_code != JSD_EGD_FAULT_UNKNOWN)
-      {
+      } else if (jsd_time_get_mono_time_sec() >
+                     (1.0 + state->fault_mono_time) &&
+                 state->pub.fault_code != JSD_EGD_FAULT_UNKNOWN) {
         // If we've been waiting for a long duration, the EMCY is not going to come
         //   go ahead an advance the state machine to prevent infinite wait. May
         //   occur on startup.

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -424,7 +424,8 @@ typedef struct {
   bool                          last_async_sdo_in_prog;
 
   // Time of statusword fault state change
-  double                        fault_time;
+  double fault_real_time;  // Used to compare against SOEM error's timestamp
+  double fault_mono_time;  // Used to compute elapsed time.
 
 } jsd_egd_private_state_t;
 

--- a/src/jsd_time.h
+++ b/src/jsd_time.h
@@ -8,6 +8,8 @@ extern "C" {
 #include <sys/time.h>
 #include <time.h>
 
+#include "ethercattype.h"
+
 /**
  * @brief Get the system's clock time since the Unix Epoch.
  * @return Number of seconds since Unix Epoch.
@@ -16,6 +18,25 @@ static inline double jsd_time_get_time_sec() {
   struct timespec ts;
   clock_gettime(CLOCK_REALTIME, &ts);
   return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000;
+}
+
+/**
+ * @brief Get monotonic time since unspecified fixed point. This function is
+ * used to compute elapsed time.
+ * @return Number of seconds since fixed point.
+ */
+static inline double jsd_time_get_mono_time_sec() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000;
+}
+
+/**
+ * @brief Convert SOEM's time type to seconds.
+ * @return Seconds representation of SOEM's time type object.
+ */
+static inline double ectime_to_sec(ec_timet t) {
+  return (double)t.sec + (double)(t.usec) * 1.0e-6;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Summary:
Adds function to get a time reference from the monotonic clock so that elapsed time can be computed.

Test Plan:
Ran jsd_egd_test on the Playground testbed and forced some velocity tracking errors. Behavior was equivalent to before the change.

Reviewers: alex-brinkman