### PR TITLE
Removed unnecessary sms transition

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -1268,15 +1268,10 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
         break;
       }
 
-      set_controlword(self, slave_id,
-                      JSD_EGD_STATE_MACHINE_CONTROLWORD_ENABLE_OPERATION);
-
       jsd_egd_process_mode_of_operation(self, slave_id);
 
       break;
     case JSD_EGD_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE:
-      set_controlword(self, slave_id,
-                      JSD_EGD_STATE_MACHINE_CONTROLWORD_ENABLE_OPERATION);
       break;
     case JSD_EGD_STATE_MACHINE_STATE_FAULT_REACTION_ACTIVE:
       set_controlword(self, slave_id,


### PR DESCRIPTION
By default, we set quick-stop function(0x605A) with value 2: `Slow down on quick-stop ramp and then disable the drive function, go to SWITCHED ON DISABLED state`.

When motor finishes the profile, Elmo state machine state jumps to `Quick Stop Active`
If we command ELMO faster than 200hz, before the quick-stop function does the job to transit to `SWITCHED ON DISABLED` to brake the actuator, it jumps to `OPERATION_ENABLED` instead.

And when Elmo SMS is in `OPERATION_ENABLED` state, it was looping to set the controlword to stay in `OPERATION_ENABLED`, which will cause any automatic state transition not functional.

After removing those state transition, actuator was tested with 512 and 1024hz and braked properly after profile.
