### PR TITLE
Added EgdFault function to be called to purge outcoming command in ca…

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -66,6 +66,7 @@ void jsd_egd_fault(jsd_t* self, uint16_t slave_id) {
   if (self->slave_configs[slave_id].egd.drive_cmd_mode == JSD_EGD_DRIVE_CMD_MODE_CS) {
     assert(sizeof(jsd_egd_rxpdo_data_cs_mode_t) == self->ecx_context.slavelist[slave_id].Obytes);
     self->slave_states[slave_id].egd.rxpdo_cs.target_position = self->slave_states[slave_id].egd.pub.actual_position;
+    self->slave_states[slave_id].egd.rxpdo_cs.position_offset = 0;
     self->slave_states[slave_id].egd.rxpdo_cs.target_velocity = 0;
     self->slave_states[slave_id].egd.rxpdo_cs.velocity_offset = 0;
     self->slave_states[slave_id].egd.rxpdo_cs.target_torque = 0;

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -65,14 +65,14 @@ void jsd_egd_fault(jsd_t* self, uint16_t slave_id) {
   
   if (self->slave_configs[slave_id].egd.drive_cmd_mode == JSD_EGD_DRIVE_CMD_MODE_CS) {
     assert(sizeof(jsd_egd_rxpdo_data_cs_mode_t) == self->ecx_context.slavelist[slave_id].Obytes);
-    self->slave_states[slave_id].egd.rxpdo_cs.target_position = 0;
+    self->slave_states[slave_id].egd.rxpdo_cs.target_position = self->slave_states[slave_id].egd.pub.actual_position;
     self->slave_states[slave_id].egd.rxpdo_cs.target_velocity = 0;
     self->slave_states[slave_id].egd.rxpdo_cs.velocity_offset = 0;
     self->slave_states[slave_id].egd.rxpdo_cs.target_torque = 0;
   }
   else if (self->slave_configs[slave_id].egd.drive_cmd_mode == JSD_EGD_DRIVE_CMD_MODE_PROFILED) {
     assert(sizeof(jsd_egd_rxpdo_data_profiled_mode_t) == self->ecx_context.slavelist[slave_id].Obytes);
-    self->slave_states[slave_id].egd.rxpdo_prof.target_position = 0;
+    self->slave_states[slave_id].egd.rxpdo_prof.target_position = self->slave_states[slave_id].egd.pub.actual_position;
     self->slave_states[slave_id].egd.rxpdo_prof.target_velocity = 0;    
     self->slave_states[slave_id].egd.rxpdo_prof.target_torque = 0;      
   }

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -59,6 +59,30 @@ void jsd_egd_clear_errors(jsd_t* self, uint16_t slave_id) {
 
 }
 
+void jsd_egd_fault(jsd_t* self, uint16_t slave_id) {
+  assert(self);
+  assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);
+  
+  if (self->slave_configs[slave_id].egd.drive_cmd_mode == JSD_EGD_DRIVE_CMD_MODE_CS) {
+    assert(sizeof(jsd_egd_rxpdo_data_cs_mode_t) == self->ecx_context.slavelist[slave_id].Obytes);
+    self->slave_states[slave_id].egd.rxpdo_cs.target_position = 0;
+    self->slave_states[slave_id].egd.rxpdo_cs.target_velocity = 0;
+    self->slave_states[slave_id].egd.rxpdo_cs.velocity_offset = 0;
+    self->slave_states[slave_id].egd.rxpdo_cs.target_torque = 0;
+  }
+  else if (self->slave_configs[slave_id].egd.drive_cmd_mode == JSD_EGD_DRIVE_CMD_MODE_PROFILED) {
+    assert(sizeof(jsd_egd_rxpdo_data_profiled_mode_t) == self->ecx_context.slavelist[slave_id].Obytes);
+    self->slave_states[slave_id].egd.rxpdo_prof.target_position = 0;
+    self->slave_states[slave_id].egd.rxpdo_prof.target_velocity = 0;    
+    self->slave_states[slave_id].egd.rxpdo_prof.target_torque = 0;      
+  }
+  else {
+    ERROR("bad drive command mode: %d",
+          self->slave_configs[slave_id].egd.drive_cmd_mode);
+  }  
+
+}
+
 void jsd_egd_reset(jsd_t* self, uint16_t slave_id) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);

--- a/src/jsd_egd_pub.h
+++ b/src/jsd_egd_pub.h
@@ -31,6 +31,16 @@ const jsd_egd_state_t* jsd_egd_get_state(jsd_t* self, uint16_t slave_id);
 void jsd_egd_clear_errors(jsd_t* self, uint16_t slave_id);
 
 /**
+ * @brief Fault the EGD, to purge any outcoming command
+ *
+ * Real-time safe.
+ *
+ * @param self pointer JSD context
+ * @param slave_id slave id of EGD device
+ */
+void jsd_egd_fault(jsd_t* self, uint16_t slave_id);
+
+/**
  * @brief Reset the EGD after a fault and clear errors
  *
  * Real-time safe.

--- a/src/jsd_print.h
+++ b/src/jsd_print.h
@@ -5,32 +5,29 @@
 extern "C" {
 #endif
 
-#include <jsd/jsd_time.h>
+#include "jsd/jsd_time.h"
+#include "cfw/cfw_log.h"
+
 #include <stdio.h>
 
 #ifdef DEBUG
-#define MSG_DEBUG(M, ...)                                                     \
-  fprintf(stderr, "[ DEBUG ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
-          __FILE__, __LINE__, ##__VA_ARGS__)
+#define MSG_DEBUG(M, ...) \
+  cfw_log_print(CFW_DEBUG, __FILE__, __LINE__, M, ##__VA_ARGS__)
 #else
 #define MSG_DEBUG(M, ...)
 #endif
 
-#define MSG(M, ...)                                                           \
-  fprintf(stderr, "[ INFO  ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
-          __FILE__, __LINE__, ##__VA_ARGS__)
+#define MSG(M, ...) \
+  cfw_log_print(CFW_INFO, __FILE__, __LINE__, M, ##__VA_ARGS__)
 
-#define WARNING(M, ...)                                               \
-  fprintf(stderr, "\033[1;33m[ WARN  ] [%lf] (%s:%d) " M "\033[0m\n", \
-          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
+#define WARNING(M, ...) \
+  cfw_log_print(CFW_WARN, __FILE__, __LINE__, M, ##__VA_ARGS__)
 
-#define ERROR(M, ...)                                                 \
-  fprintf(stderr, "\033[1;31m[ ERROR ] [%lf] (%s:%d) " M "\033[0m\n", \
-          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
+#define ERROR(M, ...) \
+  cfw_log_print(CFW_ERROR, __FILE__, __LINE__, M, ##__VA_ARGS__)
 
-#define SUCCESS(M, ...)                                               \
-  fprintf(stderr, "\033[1;32m[SUCCESS] [%lf] (%s:%d) " M "\033[0m\n", \
-          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
+#define SUCCESS(M, ...) \
+  cfw_log_print(CFW_INFO, __FILE__, __LINE__, M, ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/src/jsd_print.h
+++ b/src/jsd_print.h
@@ -5,29 +5,32 @@
 extern "C" {
 #endif
 
-#include "jsd/jsd_time.h"
-#include "cfw/cfw_log.h"
-
+#include <jsd/jsd_time.h>
 #include <stdio.h>
 
 #ifdef DEBUG
-#define MSG_DEBUG(M, ...) \
-  cfw_log_print(CFW_DEBUG, __FILE__, __LINE__, M, ##__VA_ARGS__)
+#define MSG_DEBUG(M, ...)                                                     \
+  fprintf(stderr, "[ DEBUG ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
+          __FILE__, __LINE__, ##__VA_ARGS__)
 #else
 #define MSG_DEBUG(M, ...)
 #endif
 
-#define MSG(M, ...) \
-  cfw_log_print(CFW_INFO, __FILE__, __LINE__, M, ##__VA_ARGS__)
+#define MSG(M, ...)                                                           \
+  fprintf(stderr, "[ INFO  ] [%lf] (%s:%d) " M "\n", jsd_time_get_time_sec(), \
+          __FILE__, __LINE__, ##__VA_ARGS__)
 
-#define WARNING(M, ...) \
-  cfw_log_print(CFW_WARN, __FILE__, __LINE__, M, ##__VA_ARGS__)
+#define WARNING(M, ...)                                               \
+  fprintf(stderr, "\033[1;33m[ WARN  ] [%lf] (%s:%d) " M "\033[0m\n", \
+          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
 
-#define ERROR(M, ...) \
-  cfw_log_print(CFW_ERROR, __FILE__, __LINE__, M, ##__VA_ARGS__)
+#define ERROR(M, ...)                                                 \
+  fprintf(stderr, "\033[1;31m[ ERROR ] [%lf] (%s:%d) " M "\033[0m\n", \
+          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
 
-#define SUCCESS(M, ...) \
-  cfw_log_print(CFW_INFO, __FILE__, __LINE__, M, ##__VA_ARGS__)
+#define SUCCESS(M, ...)                                               \
+  fprintf(stderr, "\033[1;32m[SUCCESS] [%lf] (%s:%d) " M "\033[0m\n", \
+          jsd_time_get_time_sec(), __FILE__, __LINE__, ##__VA_ARGS__)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When Egd faults out, we need to purge the outgoing command so that higher level profiler can correctly use zero-based cmv_velocity to create a profile
[Related PR](https://github.com/nasa-jpl/fastcat/pull/73)

Purging is done by overwriting `RxPDO` of `target_position`, `target_velocity`, `velocity_offset` and `target_torque`.