### PR TITLE
PDO size check for EGD and EPD

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -9,6 +9,8 @@
 #include "jsd/jsd_elmo_common.h"
 #include "jsd/jsd_sdo.h"
 
+#define JSD_EGD_MAX_BYTES_PDO_CHANNEL (32)
+
 static void set_controlword(jsd_t* self, uint16_t slave_id,
                             uint16_t controlword) {
   jsd_egd_private_state_t* state = &self->slave_states[slave_id].egd;
@@ -531,6 +533,7 @@ bool jsd_egd_init(jsd_t* self, uint16_t slave_id) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);
   assert(self->ecx_context.slavelist[slave_id].eep_man == JSD_ELMO_VENDOR_ID);
+  assert(sizeof(jsd_egd_txpdo_data_t) <= JSD_EGD_MAX_BYTES_PDO_CHANNEL);
 
   ec_slavet* slaves = self->ecx_context.slavelist;
   ec_slavet* slave  = &slaves[slave_id];
@@ -548,8 +551,12 @@ bool jsd_egd_init(jsd_t* self, uint16_t slave_id) {
   state->last_reset_time         = 0;
 
   if (config->egd.drive_cmd_mode == JSD_EGD_DRIVE_CMD_MODE_CS) {
+    assert(sizeof(jsd_egd_rxpdo_data_cs_mode_t) <=
+           JSD_EGD_MAX_BYTES_PDO_CHANNEL);
     MSG_DEBUG("rxpdo_cs size: %zu Bytes", sizeof(jsd_egd_rxpdo_data_cs_mode_t));
   } else if (config->egd.drive_cmd_mode == JSD_EGD_DRIVE_CMD_MODE_PROFILED) {
+    assert(sizeof(jsd_egd_rxpdo_data_profiled_mode_t) <=
+           JSD_EGD_MAX_BYTES_PDO_CHANNEL);
     MSG_DEBUG("rxpdo_prof size: %zu Bytes",
               sizeof(jsd_egd_rxpdo_data_profiled_mode_t));
   } else {

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -9,6 +9,7 @@
 #include "jsd/jsd_sdo.h"
 
 #define JSD_EPD_MAX_ERROR_POPS_PER_CYCLE (5)
+#define JSD_EPD_MAX_BYTES_PDO_CHANNEL (128)
 
 // Pair of Elmo letter command and corresponding object dictionary index
 typedef struct {
@@ -357,6 +358,8 @@ bool jsd_epd_init(jsd_t* self, uint16_t slave_id) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EPD_PRODUCT_CODE);
   assert(self->ecx_context.slavelist[slave_id].eep_man == JSD_ELMO_VENDOR_ID);
+  assert(sizeof(jsd_epd_txpdo_data_t) <= JSD_EPD_MAX_BYTES_PDO_CHANNEL);
+  assert(sizeof(jsd_epd_rxpdo_data_t) <= JSD_EPD_MAX_BYTES_PDO_CHANNEL);
 
   ec_slavet* slave = &self->ecx_context.slavelist[slave_id];
 

--- a/src/jsd_epd_types.h
+++ b/src/jsd_epd_types.h
@@ -114,9 +114,12 @@ typedef struct {
   // Parameters set via Two-Letter-Command (TLC)
   // IMPORTANT: Elmo alias objects are different between Gold and Platinum
   // lines.
-  // TODO(dloret): Verify data types are correct for P_AC, P_DC, P_ER, P_HL, and
-  // P_LL. There are discrepancies between the description from the command
-  // reference and the DS-402 description, or the type used in the Gold line.
+  // TODO(dloret): Consider removing max_profile_accel and max_profile_decel
+  // in both Gold and Platinum drivers. AC[1] and DC[1] are only relevant at
+  // power-up when their values are assigned to objects 0x6083 and 0x6084,
+  // respectively. So setting AC[1] and DC[1] at initialization of the driver
+  // does not have an effect. Additionally, 0x6083 and 0x6084 are mapped to the
+  // RxPDO.
   double max_profile_accel;         ///< P_AC[1]. Ignored by CS mode.
   double max_profile_decel;         ///< P_DC[1]. Ignored by CS mode.
   double velocity_tracking_error;   ///< P_ER[2] cnts/s
@@ -203,7 +206,6 @@ typedef struct {
   float   drive_temperature;  ///< deg C
 } jsd_epd_state_t;
 
-// TODO(dloret): Find out the byte limit for Platinum's rPDO and tPDO.
 /**
  * @brief TxPDO struct used to read device data in SOEM IOmap
  *


### PR DESCRIPTION
Added PDO channel size limit check to initialization of Gold and Platinum motor controller drivers.