### PR TITLE
fix: resolve off-by-one issue

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -134,9 +134,9 @@ void jsd_egd_set_digital_output(jsd_t* self, uint16_t slave_id,
 
   jsd_egd_private_state_t* state = &self->slave_states[slave_id].egd;
   if (output_level > 0) {
-    state->rxpdo_cs.digital_outputs |= (0x01 << (16 + digital_output_index));
+    state->rxpdo_cs.digital_outputs |= (0x01 << (15 + digital_output_index));
   } else {
-    state->rxpdo_cs.digital_outputs &= ~(0x01 << (16 + digital_output_index));
+    state->rxpdo_cs.digital_outputs &= ~(0x01 << (15 + digital_output_index));
   }
 }
 


### PR DESCRIPTION
It was discovered that digital_output_index did not correspond to the indices expected for the ELMO digital output pins (OUT1 through OUT4) as well as the indices associated with the object (OB[1-4]). To fix this, one less bit shift is required.

Tested the new indexing on the testbed and confirmed this new shifting coincides with the expected index'ing pattern.