### PR TITLE
fix: output index issue

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -123,8 +123,7 @@ void jsd_egd_set_digital_output(jsd_t* self, uint16_t slave_id,
                                 uint8_t output_level) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);
-  assert(digital_output_index > 0);
-  assert(digital_output_index <= JSD_EGD_NUM_DIGITAL_OUTPUTS);
+  assert(digital_output_index > 0 && digital_output_index <= JSD_EGD_NUM_DIGITAL_OUTPUTS);
 
   if (self->slave_configs[slave_id].egd.drive_cmd_mode !=
       JSD_EGD_DRIVE_CMD_MODE_CS) {

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -123,7 +123,8 @@ void jsd_egd_set_digital_output(jsd_t* self, uint16_t slave_id,
                                 uint8_t output_level) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);
-  assert(digital_output_index < JSD_EGD_NUM_DIGITAL_OUTPUTS);
+  assert(digital_output_index > 0);
+  assert(digital_output_index <= JSD_EGD_NUM_DIGITAL_OUTPUTS);
 
   if (self->slave_configs[slave_id].egd.drive_cmd_mode !=
       JSD_EGD_DRIVE_CMD_MODE_CS) {

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -156,7 +156,7 @@ void jsd_epd_set_digital_output(jsd_t* self, uint16_t slave_id, uint8_t index,
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EPD_PRODUCT_CODE);
   assert(index > 0);
-  assert(index =< JSD_EPD_NUM_DIGITAL_OUTPUTS);
+  assert(index <= JSD_EPD_NUM_DIGITAL_OUTPUTS);
 
   jsd_epd_private_state_t* state = &self->slave_states[slave_id].epd;
   if (output > 0) {

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -155,8 +155,7 @@ void jsd_epd_set_digital_output(jsd_t* self, uint16_t slave_id, uint8_t index,
                                 uint8_t output) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EPD_PRODUCT_CODE);
-  assert(index > 0);
-  assert(index <= JSD_EPD_NUM_DIGITAL_OUTPUTS);
+  assert(index > 0 && index <= JSD_EPD_NUM_DIGITAL_OUTPUTS);
 
   jsd_epd_private_state_t* state = &self->slave_states[slave_id].epd;
   if (output > 0) {

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -155,13 +155,14 @@ void jsd_epd_set_digital_output(jsd_t* self, uint16_t slave_id, uint8_t index,
                                 uint8_t output) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EPD_PRODUCT_CODE);
-  assert(index < JSD_EPD_NUM_DIGITAL_OUTPUTS);
+  assert(index > 0);
+  assert(index =< JSD_EPD_NUM_DIGITAL_OUTPUTS);
 
   jsd_epd_private_state_t* state = &self->slave_states[slave_id].epd;
   if (output > 0) {
-    state->rxpdo.digital_outputs |= (0x01 << (16 + index));
+    state->rxpdo.digital_outputs |= (0x01 << (15 + index));
   } else {
-    state->rxpdo.digital_outputs &= ~(0x01 << (16 + index));
+    state->rxpdo.digital_outputs &= ~(0x01 << (15 + index));
   }
 }
 


### PR DESCRIPTION
Asserts needed to be modified to ensure we can use the 4th digital output. Additional changes were made in the platinum drive code to match that on the gold drive.