### PR TITLE
Add Stop Decel and Quick Stop Decel parameters to Elmo Platinum Drive

### DIFF
--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -626,6 +626,19 @@ int jsd_epd_config_LC_params(ecx_contextt* ecx_context, uint16_t slave_id,
     return 0;
   }
 
+  if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, jsd_epd_lc_to_do("QS"),
+                                  1, JSD_SDO_DATA_DOUBLE,
+                                  &config->epd.quick_stop_decel)) {
+    return 0;
+  }
+
+  if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, jsd_epd_lc_to_do("SD"),
+                                  1, JSD_SDO_DATA_DOUBLE,
+                                  &config->epd.stop_decel)) {
+    return 0;
+  }
+
+
   if (!jsd_sdo_set_param_blocking(ecx_context, slave_id, jsd_epd_lc_to_do("ER"),
                                   2, JSD_SDO_DATA_DOUBLE,
                                   &config->epd.velocity_tracking_error)) {

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -37,6 +37,8 @@ static const jsd_epd_lc_pair_t jsd_epd_lc_lookup_table[] = {
     {"MC", 0x31BC},
     {"PL", 0x3231},
     {"PX", 0x323D},
+    {"QS", 0x325C},
+    {"SD", 0x3295},
     {"SF", 0x3297},
     {"UM", 0x32E6},
 };

--- a/src/jsd_epd_types.h
+++ b/src/jsd_epd_types.h
@@ -122,6 +122,8 @@ typedef struct {
   // RxPDO.
   double max_profile_accel;         ///< P_AC[1]. Ignored by CS mode.
   double max_profile_decel;         ///< P_DC[1]. Ignored by CS mode.
+  double quick_stop_decel;          /// used when quick stop command sent
+  double stop_decel;                /// used for emergency stops and limit switches
   double velocity_tracking_error;   ///< P_ER[2] cnts/s
   double position_tracking_error;   ///< P_ER[3] cnts
   float  peak_current_limit;        ///< P_PL[1] A
@@ -138,6 +140,7 @@ typedef struct {
                                ///< out of position limits protection.
   int16_t brake_engage_msec;   ///< BP[1] ms, [0, 1000]
   int16_t brake_disengage_msec;  ///< BP[2] ms, [0, 1000]
+
 
   // Verification parameters
   uint32_t crc;  ///< CZ[1], changes whenever drive parameters change

--- a/test/device/jsd_epd_csp_sine_test.c
+++ b/test/device/jsd_epd_csp_sine_test.c
@@ -211,6 +211,8 @@ int main(int argc, char* argv[]) {
   config.epd.torque_slope             = 1e7;
   config.epd.max_profile_accel        = 1e6;
   config.epd.max_profile_decel        = 1e7;
+  config.epd.quick_stop_decel         = 1e7;
+  config.epd.stop_decel               = 1e7;
   config.epd.velocity_tracking_error  = 1e8;
   config.epd.position_tracking_error  = 1e9;
   config.epd.peak_current_limit       = peak_current;

--- a/test/device/jsd_epd_cst_test.c
+++ b/test/device/jsd_epd_cst_test.c
@@ -200,6 +200,8 @@ int main(int argc, char* argv[]) {
   config.epd.torque_slope             = 1e7;
   config.epd.max_profile_accel        = 1e6;
   config.epd.max_profile_decel        = 1e7;
+  config.epd.quick_stop_decel         = 1e7;
+  config.epd.stop_decel               = 1e7;
   config.epd.velocity_tracking_error  = 1e8;
   config.epd.position_tracking_error  = 1e9;
   config.epd.peak_current_limit       = peak_current;

--- a/test/device/jsd_epd_csv_sine_test.c
+++ b/test/device/jsd_epd_csv_sine_test.c
@@ -202,6 +202,8 @@ int main(int argc, char* argv[]) {
   config.epd.torque_slope             = 1e7;
   config.epd.max_profile_accel        = 1e6;
   config.epd.max_profile_decel        = 1e7;
+  config.epd.quick_stop_decel         = 1e7;
+  config.epd.stop_decel               = 1e7;
   config.epd.velocity_tracking_error  = 1e8;
   config.epd.position_tracking_error  = 1e9;
   config.epd.peak_current_limit       = peak_current;

--- a/test/device/jsd_epd_network_test.c
+++ b/test/device/jsd_epd_network_test.c
@@ -281,6 +281,8 @@ int main(int argc, char* argv[]) {
   epd_config.epd.torque_slope             = 1e7;
   epd_config.epd.max_profile_accel        = 1e6;
   epd_config.epd.max_profile_decel        = 1e7;
+  epd_config.epd.quick_stop_decel         = 1e7;
+  epd_config.epd.stop_decel               = 1e7;
   epd_config.epd.velocity_tracking_error  = 1e8;
   epd_config.epd.position_tracking_error  = 1e9;
   epd_config.epd.peak_current_limit       = peak_current;

--- a/test/device/jsd_epd_prof_pos_test.c
+++ b/test/device/jsd_epd_prof_pos_test.c
@@ -264,6 +264,8 @@ int main(int argc, char* argv[]) {
   config.epd.torque_slope             = 1e7;
   config.epd.max_profile_accel        = 1e6;
   config.epd.max_profile_decel        = 1e7;
+  config.epd.quick_stop_decel         = 1e7;
+  config.epd.stop_decel               = 1e7;
   config.epd.velocity_tracking_error  = 1e8;
   config.epd.position_tracking_error  = 1e9;
   config.epd.peak_current_limit       = peak_current;

--- a/test/device/jsd_epd_prof_torque_test.c
+++ b/test/device/jsd_epd_prof_torque_test.c
@@ -197,6 +197,8 @@ int main(int argc, char* argv[]) {
   config.epd.torque_slope             = 1e7;
   config.epd.max_profile_accel        = 1e6;
   config.epd.max_profile_decel        = 1e7;
+  config.epd.quick_stop_decel         = 1e7;
+  config.epd.stop_decel               = 1e7;
   config.epd.velocity_tracking_error  = 1e8;
   config.epd.position_tracking_error  = 1e9;
   config.epd.peak_current_limit       = peak_current;

--- a/test/device/jsd_epd_prof_vel_test.c
+++ b/test/device/jsd_epd_prof_vel_test.c
@@ -213,6 +213,8 @@ int main(int argc, char* argv[]) {
   config.epd.torque_slope             = 1e7;
   config.epd.max_profile_accel        = 1e6;
   config.epd.max_profile_decel        = 1e7;
+  config.epd.quick_stop_decel         = 1e7;
+  config.epd.stop_decel               = 1e7;
   config.epd.velocity_tracking_error  = 1e8;
   config.epd.position_tracking_error  = 1e9;
   config.epd.peak_current_limit       = peak_current;


### PR DESCRIPTION
Quick PR to expose the Stop Decel (SD) and Quick Stop Decel (SD) parameters. 

I'm working on an application which involves lifting a heavy load using a vertical axis with limit switches. It's very helpful to be able to set these deceleration parameters, especially SD which is used when a limit switch is hit. 

I've tested this PR with our own platinum twitter drives, and I've also updated and tested all the epd test cases, except the network test as I don't have the beckoff el3602. 

Also another note I didn't run a `make format` for this PR as it made quite a lot of other changes to files I didn't touch. Happy to submit a separate formatting PR. 