### PR TITLE
fix: initial commit with changes that simply ignore command if wrong …

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -123,7 +123,12 @@ void jsd_egd_set_digital_output(jsd_t* self, uint16_t slave_id,
                                 uint8_t output_level) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EGD_PRODUCT_CODE);
-  assert(digital_output_index > 0 && digital_output_index <= JSD_EGD_NUM_DIGITAL_OUTPUTS);
+
+  if (digital_output_index <= 0 || digital_output_index > JSD_EGD_NUM_DIGITAL_OUTPUTS) {
+    ERROR("The provided digital output index %d is out of range [1,%d]",
+          digital_output_index, JSD_EGD_NUM_DIGITAL_OUTPUTS);
+    return;
+  }
 
   if (self->slave_configs[slave_id].egd.drive_cmd_mode !=
       JSD_EGD_DRIVE_CMD_MODE_CS) {

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -155,7 +155,12 @@ void jsd_epd_set_digital_output(jsd_t* self, uint16_t slave_id, uint8_t index,
                                 uint8_t output) {
   assert(self);
   assert(self->ecx_context.slavelist[slave_id].eep_id == JSD_EPD_PRODUCT_CODE);
-  assert(index > 0 && index <= JSD_EPD_NUM_DIGITAL_OUTPUTS);
+
+  if (index <= 0 || index > JSD_EPD_NUM_DIGITAL_OUTPUTS) {
+    ERROR("The provided digital output index %d is out of range [1,%d]",
+          index, JSD_EPD_NUM_DIGITAL_OUTPUTS);
+    return;
+  }
 
   jsd_epd_private_state_t* state = &self->slave_states[slave_id].epd;
   if (output > 0) {


### PR DESCRIPTION
We would like to have a clean exit in the chance scenario where a user attempts to change the value of a digital output where the index does not exist (outside the valid range).
Thus, we remove the assert and simply return without making modifications.

I tested this fix on a gold drive and found it to properly ignore the request without system crash.