### PR TITLE
Adds a function in EPD driver to clear latched errors in driver's state

### DIFF
--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -123,6 +123,15 @@ void jsd_epd_reset(jsd_t* self, uint16_t slave_id) {
   }
 }
 
+void jsd_epd_clear_errors(jsd_t* self, uint16_t slave_id) {
+  assert(self);
+  assert(jsd_epd_product_code_is_compatible(
+      self->ecx_context.slavelist[slave_id].eep_id));
+
+  self->slave_states[slave_id].epd.pub.fault_code      = JSD_EPD_FAULT_OKAY;
+  self->slave_states[slave_id].epd.pub.emcy_error_code = 0;
+}
+
 void jsd_epd_halt(jsd_t* self, uint16_t slave_id) {
   assert(self);
   assert(jsd_epd_product_code_is_compatible(

--- a/src/jsd_epd_pub.h
+++ b/src/jsd_epd_pub.h
@@ -52,6 +52,16 @@ void jsd_epd_process(jsd_t* self, uint16_t slave_id);
 void jsd_epd_reset(jsd_t* self, uint16_t slave_id);
 
 /**
+ * @brief Clears the state's latched errors.
+ *
+ * Real-time safe
+ *
+ * @param self Pointer to JSD context
+ * @param slave_id Slave ID of EPD device
+ */
+void jsd_epd_clear_errors(jsd_t* self, uint16_t slave_id);
+
+/**
  * @brief Halts the EPD. Requires reset to clear.
  *
  * Real-time safe


### PR DESCRIPTION
Adds a function in the EPD driver to clear latched errors in the driver's state. This function is needed in Fastcat to reset the drive from a Faulted state at the Fastcat level. Otherwise, Fastcat's state machine circles between Halted and Faulted because the transition into Halted requires the latched errors in the underlying JSD driver's state to be cleared.

Test Plan:
Tested on a Platinum connected with a motor through ros1/Fcat by inducing a velocity tracking error during a position command, resetting the actuator, and sending the command again. The second command was successfully followed.