### PR TITLE
Fixes Quick Stop transition in EPD driver

### DIFF
--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -418,7 +418,6 @@ bool jsd_epd_init(jsd_t* self, uint16_t slave_id) {
 
   state->setpoint_ack                  = 0;
   state->last_setpoint_ack             = 0;
-  state->prof_pos_waiting_setpoint_ack = false;
 
   return true;
 }
@@ -845,8 +844,6 @@ void jsd_epd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
             state->pub.actual_state_machine_state),
         state->pub.actual_state_machine_state);
 
-    state->prof_pos_waiting_setpoint_ack = false;
-
     if (state->pub.actual_state_machine_state ==
         JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
       // TODO(dloret): Check if setting state->new_reset to false like in EGD
@@ -947,11 +944,6 @@ void jsd_epd_process_state_machine(jsd_t* self, uint16_t slave_id) {
         state->rxpdo.mode_of_operation     = state->requested_mode_of_operation;
         break;
       }
-      // Set the controlword to a known value before potentially setting its
-      // mode of operation bits for profiled position mode. It does not
-      // represent a transition.
-//      state->rxpdo.controlword =
-//          JSD_EPD_STATE_MACHINE_CONTROLWORD_ENABLE_OPERATION;
       jsd_epd_process_mode_of_operation(self, slave_id);
       break;
     case JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE:
@@ -1035,12 +1027,6 @@ void jsd_epd_process_mode_of_operation(jsd_t* self, uint16_t slave_id) {
 
   jsd_epd_private_state_t* state = &self->slave_states[slave_id].epd;
 
-  // TODO(dloret): EGD code prints mode of operation change and warns about
-  // changing mode of operation during motion.
-  if (state->last_requested_mode_of_operation !=
-      state->requested_mode_of_operation) {
-    state->prof_pos_waiting_setpoint_ack = false;
-  }
   state->last_requested_mode_of_operation = state->requested_mode_of_operation;
 
   switch (state->requested_mode_of_operation) {
@@ -1151,20 +1137,17 @@ void jsd_epd_mode_of_op_handle_prof_pos(jsd_t* self, uint16_t slave_id) {
   state->rxpdo.profile_accel    = cmd.prof_pos.profile_accel;
   state->rxpdo.profile_decel    = cmd.prof_pos.profile_decel;
 
+  // Signal new set-point
   // Having the new set-point bit on until the drive acknowledges reception of
   // the command is necessary so that the drive does not miss the bit when
   // changing between modes of operation.
   if (state->new_motion_command) {
-    state->prof_pos_waiting_setpoint_ack = true;
-  }
-  if (state->prof_pos_waiting_setpoint_ack) {
-    // Signal new set-point
     state->rxpdo.controlword |= (0x01 << 4);
   }
   if (state->pub.setpoint_ack_rise) {
     // After the rise of set-point acknowledge bit in statusword, new set-point
     // bit in controlword can be turned off.
-    state->prof_pos_waiting_setpoint_ack = false;
+    state->rxpdo.controlword &= ~(0x01 << 4);
   }
 
   // Request immediate change of set-point

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -950,8 +950,8 @@ void jsd_epd_process_state_machine(jsd_t* self, uint16_t slave_id) {
       // Set the controlword to a known value before potentially setting its
       // mode of operation bits for profiled position mode. It does not
       // represent a transition.
-      state->rxpdo.controlword =
-          JSD_EPD_STATE_MACHINE_CONTROLWORD_ENABLE_OPERATION;
+//      state->rxpdo.controlword =
+//          JSD_EPD_STATE_MACHINE_CONTROLWORD_ENABLE_OPERATION;
       jsd_epd_process_mode_of_operation(self, slave_id);
       break;
     case JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE:

--- a/src/jsd_epd_types.h
+++ b/src/jsd_epd_types.h
@@ -305,13 +305,6 @@ typedef struct {
   uint8_t setpoint_ack;  ///< Setpoint ackowledge (Profiled Position mode),
                          ///< statustword, bit 12
   uint8_t last_setpoint_ack;
-  bool prof_pos_waiting_setpoint_ack;  ///< When in Profiled Position mode, it
-                                       ///< indicates whether the driver is
-                                       ///< waiting for the drive to acknowledge
-                                       ///< reception of a new profiled position
-                                       ///< set-point so that the driver can
-                                       ///< turn off the new set-point bit in
-                                       ///< the controlword.
 } jsd_epd_private_state_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
EPD driver requested an Enable Operation's state machine transition inadvertently during Quick Stop Active.

The firmware in Platinum drives should ignore such request if Quick Stop Option Code is set to 2. However, some drives do not follow the documented behavior and transition into Enabled Operation from Quick Stop Active. As a consequence of this, if there is a brake configured in the drive, the brake will remain engaged after the Quick Stop.

Test Plan:
Tested on Safety and non-Safety Platinum drives connected to motors. The test consisted on sending one profiled position command, and sending a second one after completion of the first. Now the state machine does not transition to Enabled Operation from Quick Stop Active, and the motor's brake is engaged and disengaged properly.