### PR TITLE
Dwai jsd compile time verbosity level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 project(jsd
     DESCRIPTION "JPL SOEM Drivers"
-    VERSION 2.3.6
+    VERSION 2.3.7
     LANGUAGES C CXX
     )
 

--- a/src/jsd_ati_fts.c
+++ b/src/jsd_ati_fts.c
@@ -148,6 +148,9 @@ int jsd_ati_fts_PO2SO_config(ecx_contextt* ecx_context, uint16_t slave_id) {
   const char* torque_unit_str =
       jsd_ati_fts_torque_unit_to_string(cal_do.torque_units);
 
+  (void) force_unit_str;
+  (void) torque_unit_str;
+
   MSG("\t ATI Serial Number: %s", cal_do.serial_number);
   MSG("\t ATI Calibration Integer (%u) maps to: %s",
       config->ati_fts.calibration, cal_do.calibration_part_number);
@@ -179,6 +182,8 @@ int jsd_ati_fts_PO2SO_config(ecx_contextt* ecx_context, uint16_t slave_id) {
 
 bool jsd_ati_fts_parse_status_code(uint32_t status_code, uint16_t slave_id) {
   bool active_fault = false;
+
+  (void) slave_id;
 
   if ((status_code >> 0) % 0x01) {
     MSG("ATI FTS [%u] - Monitor Condition Tripped", slave_id);

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -765,6 +765,13 @@ int jsd_egd_config_COE_params(ecx_contextt* ecx_context, uint16_t slave_id,
   bool prof_csv_sup    = (supported_drive_modes & (0x01 << 8));
   bool prof_cst_sup    = (supported_drive_modes & (0x01 << 9));
 
+  (void) prof_pos_sup;
+  (void) prof_vel_sup;
+  (void) prof_torque_sup;
+  (void) prof_csp_sup;
+  (void) prof_csv_sup;
+  (void) prof_cst_sup;
+
   if(!prof_pos_sup) {
     ERROR("EGD[%d] does not support PROF_POS mode. A valid position controller must be tuned before use", 
         slave_id);


### PR DESCRIPTION
Suppress more unused variable warnings when setting log level to FATAL or WARNING. Thanks to Dennis Wai for the contribution.