### PR TITLE
fix: initial commit

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -1230,6 +1230,7 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
     case JSD_ELMO_STATE_MACHINE_STATE_SWITCH_ON_DISABLED:
       set_controlword(self, slave_id,
                       JSD_EGD_STATE_MACHINE_CONTROLWORD_SHUTDOWN);
+      state->new_halt_command   = false; // Ensure that previous unhandled halts are ignored
       // to READY_TO_SWITCH_ON
       break;
     case JSD_ELMO_STATE_MACHINE_STATE_READY_TO_SWITCH_ON:
@@ -1268,6 +1269,7 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
         state->requested_mode_of_operation = JSD_EGD_MODE_OF_OPERATION_PROF_POS;
         set_mode_of_operation(self, slave_id,
                               state->requested_mode_of_operation);
+        state->new_halt_command   = false;
         break;
       }
 
@@ -1332,7 +1334,6 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
   }
 
   state->new_motion_command = false;
-  state->new_halt_command   = false;
 }
 
 void jsd_egd_mode_of_op_handle_prof_pos(jsd_t* self, uint16_t slave_id) {

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -909,6 +909,7 @@ void jsd_epd_process_state_machine(jsd_t* self, uint16_t slave_id) {
     case JSD_ELMO_STATE_MACHINE_STATE_SWITCH_ON_DISABLED:
       // Transition to READY TO SWITCH ON
       state->rxpdo.controlword = JSD_EPD_STATE_MACHINE_CONTROLWORD_SHUTDOWN;
+      state->new_halt_command = false;
       break;
     case JSD_ELMO_STATE_MACHINE_STATE_READY_TO_SWITCH_ON:
       // Transition to SWITCHED ON
@@ -924,6 +925,7 @@ void jsd_epd_process_state_machine(jsd_t* self, uint16_t slave_id) {
         state->requested_mode_of_operation = JSD_EPD_MODE_OF_OPERATION_PROF_POS;
         state->rxpdo.mode_of_operation     = state->requested_mode_of_operation;
         state->new_reset                   = false;
+        state->new_halt_command            = false;
       }
       break;
     case JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED:
@@ -1017,7 +1019,6 @@ void jsd_epd_process_state_machine(jsd_t* self, uint16_t slave_id) {
       assert(0);
   }
   state->new_motion_command = false;
-  state->new_halt_command   = false;
 }
 
 void jsd_epd_process_mode_of_operation(jsd_t* self, uint16_t slave_id) {


### PR DESCRIPTION
It was found that if a fault occurs slightly after commands are sent from fastcat, it is possible that a halt could be sent before the JSD level has time to transition to its operational state.

Error scenario: 
Motion commands are sent and then a fault immediately occurs resulting in the immediate sending of the halt command. 

![image](https://github.com/nasa-jpl/jsd/assets/128186734/5788bb2b-fb53-4be7-ac5d-8a5a05ef2970)


We see in this graph that the actuator transitions from "1" (HALTED) to "9" (ACTUATOR_SMS_CS) to "0" (FAULT). Within the same cycle, the JSD level transitions from "35" (JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON) to "39" (JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED). It then proceeds to stay enabled perpetually running at the command set when the actuator state was in ACTUATOR_SMS_CS.

Why this occurs:
If the halt command is processed before JSD has a chance to change to state "39" (JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED), the halt command is simply ignored.  

To explain why the graph shows the actuator state changing at the same time as the JSD Elmo state, we need to understand the order of operations when a single loop is carried out:
Read stage - The current state of JSD is read from the gold drive
Write stage - Commands are sent to JSD (such as CST)
Process stage - The written commands are processed

After these three steps are taken care of in the cycle, the actuator states and egd/epd states are updated on the telemetry.

Keep in mind that within a single loop cycle (updates in the jsd read stage), the egd state actually updates before the actuator state updates.

So even though it appears as though the two states change simultaneously, truly JSD switches states first and then the actuator switches states.


Nevertheless, the important bit is the cycle before JSD switches to Operation enabled. In this cycle, JSD is in JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON when Fault() is called on the actuator. After Fault() is called (carried out by ExecuteAllDeviceFaults()), the JSD Process() function is called (calling jsd_egd_process() and jsd_egd_process_state_machine()) which ignore the halt.

The fix:
To fix this, we ensured a halt cannot be ignored by only changing new_halt_command to false after it is carried out. 
To avoid complications that could arise if a hardware-level fault occurs between calling the halt command and  carrying it out, we also make sure to set this flag to false in JSD_ELMO_STATE_MACHINE_STATE_SWITCH_ON_DISABLED (the starting state).

Doing this produced the following behavior:
![image](https://github.com/nasa-jpl/jsd/assets/128186734/f4dc996f-663f-46e5-b9e0-6e08b111a744)

