### PR TITLE
Fix persistent halt command

### DIFF
--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -1245,7 +1245,6 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
       // STO drops us here
       // Handle reset
       if (state->new_reset) {
-        // Process the new reset command
         set_controlword(self, slave_id,
           JSD_EGD_STATE_MACHINE_CONTROLWORD_ENABLE_OPERATION);
 

--- a/src/jsd_egd.c
+++ b/src/jsd_egd.c
@@ -604,6 +604,8 @@ bool jsd_egd_init(jsd_t* self, uint16_t slave_id) {
   state->pub.fault_code = JSD_EGD_FAULT_OKAY;
   state->pub.emcy_error_code = 0;
 
+  state->enabling_operation = false;
+
   return true;
 }
 
@@ -1153,6 +1155,7 @@ void jsd_egd_update_state_from_PDO_data(jsd_t* self, uint16_t slave_id) {
     if (state->pub.actual_state_machine_state ==
         JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
       jsd_sdo_signal_emcy_check(self);
+      state->enabling_operation = false; // we should not be carrying out reset currently
       state->new_reset = false; // clear any potentially ongoing reset request
       state->fault_real_time = jsd_time_get_time_sec();
       state->fault_mono_time = jsd_time_get_mono_time_sec();
@@ -1336,7 +1339,9 @@ void jsd_egd_process_state_machine(jsd_t* self, uint16_t slave_id) {
   }
 
   state->new_motion_command = false;
-  if (!state->enabling_operation) state->new_halt_command = false;
+  if (!state->enabling_operation) {
+    state->new_halt_command = false;
+  }
 }
 
 void jsd_egd_mode_of_op_handle_prof_pos(jsd_t* self, uint16_t slave_id) {

--- a/src/jsd_egd_types.h
+++ b/src/jsd_egd_types.h
@@ -294,6 +294,7 @@ typedef struct {
   uint32_t motor_rated_current;  ///< CL[1] in mA
 
   // user input
+  bool                        enabling_operation;
   bool                        new_reset;
   bool                        new_halt_command;
   bool                        new_motion_command;

--- a/src/jsd_epd.c
+++ b/src/jsd_epd.c
@@ -108,7 +108,7 @@ void jsd_epd_reset(jsd_t* self, uint16_t slave_id) {
   if ((now - self->slave_states[slave_id].epd.last_reset_time) >
       JSD_EPD_RESET_DERATE_SEC) {
     // Flag below used to latch halt commands until we are in the OPERATION ENABLED state.
-    self->slave_states[slave_id].egd.enabling_operation = true;
+    self->slave_states[slave_id].epd.enabling_operation = true;
     
     self->slave_states[slave_id].epd.new_reset       = true;
     self->slave_states[slave_id].epd.last_reset_time = now;

--- a/src/jsd_epd_types.h
+++ b/src/jsd_epd_types.h
@@ -277,6 +277,7 @@ typedef struct {
                                  ///< (CL[1]), mA
 
   // User input
+  bool                        enabling_operation;
   bool                        new_reset;
   bool                        new_halt_command;
   bool                        new_motion_command;


### PR DESCRIPTION
This pull request is a follow up of the previous pull request for fix-persistent-halt-command.

This pull request solves the problem using a flag that ensures that the ELMO has time to switch to operation enabled before processing halt commands.

Thus far, this implementation is untested.