### PR TITLE
Added bad_wkc variable to track bad working counters and send info to…

### DIFF
--- a/src/jsd.c
+++ b/src/jsd.c
@@ -155,7 +155,6 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
                        self->ecx_context.grouplist[0].inputsWKC;
 
   self->last_wkc = -1;  // -1 is returned on first read
-  self->bad_wkc = false; // We are currently not experiencing a bad working counter
 
   MSG_DEBUG("Calculated workcounter %d", self->expected_wkc);
 
@@ -233,13 +232,11 @@ void jsd_read(jsd_t* self, int timeout_us) {
   // Wait for EtherCat frame to return from slaves, with logic for smart prints
   self->wkc = ecx_receive_processdata(&self->ecx_context, timeout_us);
   if (self->wkc != self->expected_wkc && self->last_wkc != self->wkc) {
-    self->bad_wkc = true;
     WARNING("ecx_receive_processdata returning bad wkc: %d (expected: %d)",
             self->wkc, self->expected_wkc);
   }
   if (self->last_wkc != self->expected_wkc && self->wkc == self->expected_wkc) {
     if (self->last_wkc != -1) {
-      self->bad_wkc = false;
       MSG("ecx_receive_processdata is no longer reading bad wkc");
     }
   }

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -155,6 +155,7 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
                        self->ecx_context.grouplist[0].inputsWKC;
 
   self->last_wkc = -1;  // -1 is returned on first read
+  self->bad_wkc = false; // We are currently not experiencing a bad working counter
 
   MSG_DEBUG("Calculated workcounter %d", self->expected_wkc);
 
@@ -232,12 +233,14 @@ void jsd_read(jsd_t* self, int timeout_us) {
   // Wait for EtherCat frame to return from slaves, with logic for smart prints
   self->wkc = ecx_receive_processdata(&self->ecx_context, timeout_us);
   if (self->wkc != self->expected_wkc && self->last_wkc != self->wkc) {
+    self->bad_wkc = true;
     WARNING("ecx_receive_processdata returning bad wkc: %d (expected: %d)",
             self->wkc, self->expected_wkc);
   }
   if (self->last_wkc != self->expected_wkc && self->wkc == self->expected_wkc) {
     if (self->last_wkc != -1) {
-      MSG("ecx_receive_processdata is not longer reading bad wkc");
+      self->bad_wkc = false;
+      MSG("ecx_receive_processdata is no longer reading bad wkc");
     }
   }
   self->last_wkc = self->wkc;

--- a/src/jsd_types.h
+++ b/src/jsd_types.h
@@ -177,6 +177,7 @@ typedef struct {
   int          expected_wkc;             ///< Expected Working Counter
   int          wkc;                      ///< processdata Working Counter
   int          last_wkc;                 ///< the previous processdata wkc
+  bool         bad_wkc;                  ///< true if experiencing bad Working Counter
   bool         init_complete;            ///< true after jsd_init(...)
   uint8_t      enable_autorecovery;      ///< enables autorecovery feature
   uint8_t      attempt_manual_recovery;  ///< one-time manual recovery attempt

--- a/src/jsd_types.h
+++ b/src/jsd_types.h
@@ -177,7 +177,6 @@ typedef struct {
   int          expected_wkc;             ///< Expected Working Counter
   int          wkc;                      ///< processdata Working Counter
   int          last_wkc;                 ///< the previous processdata wkc
-  bool         bad_wkc;                  ///< true if experiencing bad Working Counter
   bool         init_complete;            ///< true after jsd_init(...)
   uint8_t      enable_autorecovery;      ///< enables autorecovery feature
   uint8_t      attempt_manual_recovery;  ///< one-time manual recovery attempt


### PR DESCRIPTION
This MR introduces a bad_wkc variable in the jsd_t that is used by the higher-level fastcat module for creating a bad working counter state in the actuator state machine.