### PR TITLE
Prestonr feature add wkc driver saves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ include(FetchContent)
 
 # Updated 2022-09-18
 FetchContent_Declare(soem
-  GIT_REPOSITORY https://github.com/OpenEtherCATsociety/SOEM.git
-  GIT_TAG 26fc5dd8e3c8981b4e8f83d736e691417bebacdb
+  GIT_REPOSITORY git@github.com:preston-rogers/SOEM.git
+  GIT_TAG prestonr-feature-add-wkc-driver-saves
     )
 FetchContent_MakeAvailable(soem)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ include(FetchContent)
 
 # Updated 2022-09-18
 FetchContent_Declare(soem
-  GIT_REPOSITORY https://github.com/preston-rogers/SOEM.git
-  GIT_TAG prestonr-feature-add-wkc-driver-saves
+  GIT_REPOSITORY https://github.com/OpenEtherCATsociety/SOEM.git
+  GIT_TAG 26fc5dd8e3c8981b4e8f83d736e691417bebacdb
     )
 FetchContent_MakeAvailable(soem)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ include(FetchContent)
 
 # Updated 2022-09-18
 FetchContent_Declare(soem
-  GIT_REPOSITORY git@github.com:preston-rogers/SOEM.git
+  GIT_REPOSITORY https://github.com/preston-rogers/SOEM.git
   GIT_TAG prestonr-feature-add-wkc-driver-saves
     )
 FetchContent_MakeAvailable(soem)

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -165,14 +165,18 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   self->ecx_context.slavelist[0].state = EC_STATE_OPERATIONAL;
 
   ecx_send_overlap_processdata(&self->ecx_context);
-  ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET);
+  uint64_t *bad_wkc_indices;
+  *bad_wkc_indices = 0;
+  ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET, bad_wkc_indices);
 
   ecx_writestate(&self->ecx_context, 0);
 
   int attempt = 0;
   while (true) {
     int sent = ecx_send_overlap_processdata(&self->ecx_context);
-    int wkc  = ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET);
+    uint64_t *bad_wkc_indices;
+    *bad_wkc_indices = 0;
+    int wkc  = ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET, bad_wkc_indices);
     ec_state actual_state = ecx_statecheck(
         &self->ecx_context, 0, EC_STATE_OPERATIONAL, EC_TIMEOUTSTATE);
 

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -281,7 +281,6 @@ void jsd_read(jsd_t* self, int timeout_us) {
     WARNING("ecx_receive_processdata returning bad wkc: %d (expected: %d)",
             self->wkc, self->expected_wkc);
   }
-  
   if (self->last_wkc != self->expected_wkc && self->wkc == self->expected_wkc) {
     if (self->last_wkc != -1) {
       MSG("ecx_receive_processdata is not longer reading bad wkc");

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -272,8 +272,16 @@ void jsd_inspect_context(jsd_t* self) {
     MSG("All slaves were operational at time of working counter fault.");
   }
   else {
-    MSG("Some slaves were not operational. Error list displayed below:\n %s", ecx_elist2string(self->ecx_context));
+    MSG("Some slaves were not operational.");
+    if (self->ecx_context.ecaterror) {
+      MSG("We experienced an ECAT error. When this occurs, error information aught to be saved. "
+          "Error list displayed below:\n %s", ecx_elist2string(self->ecx_context));
+    }
+    else {
+      MSG("Despite some slaves not being operational, an ECAT error was not experienced.");
+    }
   }
+
 }
 
 void jsd_read(jsd_t* self, int timeout_us) {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -273,10 +273,19 @@ void jsd_inspect_context(jsd_t* self) {
   else {
     MSG("Some slaves were not operational.");
     if (self->ecx_context.ecaterror) {
-      MSG("We experienced an ECAT error. When this occurs, error information aught to be saved. "
-          "Errors in error list displayed below:\n");
-      while(self->ecx_context.ecaterror) MSG("%s\n", ecx_elist2string(&self->ecx_context));
-      MSG("Went through all errors in the elist stack.\n");
+      MSG("An ECAT error occurred; the error list is displayed below:");
+      uint8_t i = 0; 
+      while(self->ecx_context.ecaterror && i < JSD_ELIST_MAX_READS) {
+        MSG("%s\n", ecx_elist2string(&self->ecx_context));
+        i++;
+      }
+      if (i == JSD_ELIST_MAX_READS) {
+        MSG("Maximum number of reads from error list experienced."
+            " This is likely a result of indefinite polling.");
+      }
+      else {
+        MSG("Finished reporting errors in error list.");
+      }
     }
     else {
       MSG("Despite some slaves not being operational, an ECAT error was not experienced.");

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -198,6 +198,8 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
       WARNING("Failed OP transition attempt %d of %d", attempt,
               JSD_PO2OP_MAX_ATTEMPTS);
 
+      jsd_inspect_context(self);
+
       if (attempt >= JSD_PO2OP_MAX_ATTEMPTS) {
         ERROR("Max number of attempts to transition to OPERATIONAL exceeded.");
         return false;

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -275,13 +275,14 @@ void jsd_inspect_context(jsd_t* self) {
     MSG("Some slaves were not operational.");
     if (self->ecx_context.ecaterror) {
       MSG("We experienced an ECAT error. When this occurs, error information aught to be saved. "
-          "Error list displayed below:\n %s", ecx_elist2string(self->ecx_context));
+          "Errors in error list displayed below:\n");
+      while(self->ecx_context.ecaterror) MSG("%s\n", ecx_elist2string(&self->ecx_context));
+      MSG("Went through all errors in the elist stack.\n");
     }
     else {
       MSG("Despite some slaves not being operational, an ECAT error was not experienced.");
     }
   }
-
 }
 
 void jsd_read(jsd_t* self, int timeout_us) {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -242,7 +242,6 @@ void jsd_inspect_context(jsd_t* self) {
   /* first check if the jsd bus is operational so we can get more info */
   if (bus_state != EC_STATE_OPERATIONAL) {
     ERROR("JSD bus is not OPERATIONAL.");
-    return;
   }
 
   /* one or more slaves may not be responding */
@@ -271,6 +270,9 @@ void jsd_inspect_context(jsd_t* self) {
 
   if (total_operational_devices == *self->ecx_context.slavecount) {
     MSG("All slaves were operational at time of working counter fault.");
+  }
+  else {
+    MSG("Some slaves were not operational. Error list displayed below:\n %s", ecx_elist2string(self->ecx_context));
   }
 }
 

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -260,7 +260,6 @@ bool jsd_all_slaves_operational(jsd_t* self) {
 }
 
 void jsd_inspect_context(jsd_t* self) {
-  uint8_t currentgroup = 0;  // only 1 rate group in JSD currently
   ec_state bus_state = jsd_get_device_state(self, 0);
 
   /* first check if the jsd bus is operational so we can get more info */

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -231,7 +231,7 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
 bool jsd_all_slaves_operational(jsd_t* self) {
   int slave;
   bool all_slaves_operational = true;
-
+  uint8_t currentgroup = 0;  // only 1 rate group in JSD currently
   /* one or more slaves may not be responding */
   for (slave = 1; slave <= *self->ecx_context.slavecount; slave++) {
     if (self->ecx_context.slavelist[slave].group != currentgroup) continue;

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -244,27 +244,21 @@ void jsd_inspect_context(jsd_t* self) {
   }
 
   /* one or more slaves may not be responding */
-  ecx_readstate(&self->ecx_context);
   for (slave = 1; slave <= *self->ecx_context.slavecount; slave++) {
-
     if (self->ecx_context.slavelist[slave].group != currentgroup) continue;
 
+    /* re-check bad slave individually */
+    ecx_statecheck(&self->ecx_context, slave, EC_STATE_OPERATIONAL, EC_TIMEOUTRET);
     if (self->ecx_context.slavelist[slave].state != EC_STATE_OPERATIONAL) {
       if (self->ecx_context.slavelist[slave].state ==
           (EC_STATE_SAFE_OP + EC_STATE_ERROR)) {
         ERROR("slave[%d] is in SAFE_OP + ERROR.", slave);
-      } else if (self->ecx_context.slavelist[slave].state ==
-                  EC_STATE_SAFE_OP) {
+      } else if (self->ecx_context.slavelist[slave].state == EC_STATE_SAFE_OP) {
         ERROR("slave[%d] is in SAFE_OP.", slave);
       } else if (self->ecx_context.slavelist[slave].state > EC_STATE_NONE) {
         ERROR("slave[%d] is in state with hexadecimal: %x", self->ecx_context.slavelist[slave].state);
       } else {
-        /* re-check bad slave individually */
-        ecx_statecheck(&self->ecx_context, slave, EC_STATE_OPERATIONAL,
-                        EC_TIMEOUTRET);
-        if (self->ecx_context.slavelist[slave].state == EC_STATE_NONE) {
-          ERROR("slave[%d] is lost", slave);
-        }
+        ERROR("slave[%d] is lost", slave);
       }
     }
     else {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -241,13 +241,13 @@ void jsd_read(jsd_t* self, int timeout_us) {
     // slavecount does not include the 0 index virtual device master
     assert(num_slaves + 1 <= 64); // We can only keep track of 64 slaves (TODO: check if master is included in this number) 
     ec_slavet* slaves = self->ecx_context.slavelist;
-    uint16_t   slave_idx;
+    uint64_t   slave_idx;
 
     // slavecount does not include the 0 index virtual device master
     for (slave_idx = 1; slave_idx < num_slaves + 1; ++slave_idx) {
       ec_slavet* slave = &slaves[slave_idx];
       // Go through every bit and see if any device was set to 1 due to bad wkc
-      bool bad_device_wkc = bad_wkc_indices & (1 << slave_idx); 
+      bool bad_device_wkc = *bad_wkc_indices & (1 << slave_idx); 
       if (bad_device_wkc) {
         WARNING("Device (%s) index caused a bad working counter: %d", slave->name, device_idx);
       }

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -237,19 +237,18 @@ void jsd_read(jsd_t* self, int timeout_us) {
     WARNING("ecx_receive_processdata returning bad wkc: %d (expected: %d)",
             self->wkc, self->expected_wkc);
  
-    uint16_t num_slaves = *(self->ecx_context.slavecount);
-    // slavecount does not include the 0 index virtual device master
-    assert(num_slaves + 1 <= 64); // We can only keep track of 64 slaves (TODO: check if master is included in this number) 
+    uint16_t num_slaves = *(self->ecx_context.slavecount) + 1; // slavecount does not include the 0 index virtual device master
+    assert(num_slaves <= 64); // We can only keep track of 64 slaves (TODO: check if master is included in this number) 
     ec_slavet* slaves = self->ecx_context.slavelist;
-    uint64_t   slave_idx;
+    uint16_t   slave_idx;
 
     // slavecount does not include the 0 index virtual device master
-    for (slave_idx = 1; slave_idx < num_slaves + 1; ++slave_idx) {
+    for (slave_idx = 1; slave_idx < num_slaves; slave_idx++) {
       ec_slavet* slave = &slaves[slave_idx];
       // Go through every bit and see if any device was set to 1 due to bad wkc
       bool bad_device_wkc = *bad_wkc_indices & (1 << slave_idx); 
       if (bad_device_wkc) {
-        WARNING("Device (%s) index caused a bad working counter: %d", slave->name, device_idx);
+        WARNING("Device (%s) index caused a bad working counter: %d", slave->name, slave_idx);
       }
     }
   }

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -165,8 +165,8 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   self->ecx_context.slavelist[0].state = EC_STATE_OPERATIONAL;
 
   ecx_send_overlap_processdata(&self->ecx_context);
-  uint64_t *bad_wkc_indices;
-  *bad_wkc_indices = 0;
+  uint64 bad_wkc_indices_val = 0;
+  uint64* bad_wkc_indices = &bad_wkc_indices_val;
   ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET, bad_wkc_indices);
 
   ecx_writestate(&self->ecx_context, 0);
@@ -174,8 +174,8 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   int attempt = 0;
   while (true) {
     int sent = ecx_send_overlap_processdata(&self->ecx_context);
-    uint64_t *bad_wkc_indices;
-    *bad_wkc_indices = 0;
+    uint64 bad_wkc_indices_val = 0;
+    uint64* bad_wkc_indices = &bad_wkc_indices_val;
     int wkc  = ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET, bad_wkc_indices);
     ec_state actual_state = ecx_statecheck(
         &self->ecx_context, 0, EC_STATE_OPERATIONAL, EC_TIMEOUTSTATE);
@@ -234,8 +234,8 @@ void jsd_read(jsd_t* self, int timeout_us) {
   assert(self);
 
   // Wait for EtherCat frame to return from slaves, with logic for smart prints
-  uint64* bad_wkc_indices;
-  *bad_wkc_indices = 0;
+  uint64 bad_wkc_indices_val = 0;
+  uint64* bad_wkc_indices = &bad_wkc_indices_val;
   self->wkc = ecx_receive_processdata(&self->ecx_context, timeout_us, bad_wkc_indices);
   if (self->wkc != self->expected_wkc && self->last_wkc != self->wkc) {
     WARNING("ecx_receive_processdata returning bad wkc: %d (expected: %d)",
@@ -250,7 +250,7 @@ void jsd_read(jsd_t* self, int timeout_us) {
     for (slave_idx = 1; slave_idx < num_slaves; slave_idx++) {
       ec_slavet* slave = &slaves[slave_idx];
       // Go through every bit and see if any device was set to 1 due to bad wkc
-      bool bad_device_wkc = *bad_wkc_indices & (1 << slave_idx); 
+      bool bad_device_wkc = bad_wkc_indices_val & (1 << slave_idx); 
       if (bad_device_wkc) {
         WARNING("Device (%s) index caused a bad working counter: %d", slave->name, slave_idx);
       }

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -237,7 +237,7 @@ void jsd_inspect_context(jsd_t* self) {
 
   ec_state bus_state = jsd_get_device_state(self, 0);
 
-  /* first check if the jsd bus is operational so we can ge tmore info */
+  /* first check if the jsd bus is operational so we can get more info */
   if (bus_state != EC_STATE_OPERATIONAL) {
     ERROR("JSD bus is not OPERATIONAL.");
     return;

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -256,7 +256,7 @@ void jsd_inspect_context(jsd_t* self) {
       } else if (self->ecx_context.slavelist[slave].state == EC_STATE_SAFE_OP) {
         ERROR("slave[%d] is in SAFE_OP.", slave);
       } else if (self->ecx_context.slavelist[slave].state > EC_STATE_NONE) {
-        ERROR("slave[%d] is in state with hexadecimal: %x", self->ecx_context.slavelist[slave].state);
+        ERROR("slave[%d] is in state with hexadecimal: %x", slave, self->ecx_context.slavelist[slave].state);
       } else {
         ERROR("slave[%d] is lost", slave);
       }
@@ -268,7 +268,7 @@ void jsd_inspect_context(jsd_t* self) {
   }
 
   if (total_operational_devices == *self->ecx_context.slavecount) {
-    MSG("All slaves were operational at time of working counter fault.", slave);
+    MSG("All slaves were operational at time of working counter fault.");
   }
 }
 

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -165,18 +165,14 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
   self->ecx_context.slavelist[0].state = EC_STATE_OPERATIONAL;
 
   ecx_send_overlap_processdata(&self->ecx_context);
-  uint64 bad_wkc_indices_val = 0;
-  uint64* bad_wkc_indices = &bad_wkc_indices_val;
-  ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET, bad_wkc_indices);
+  ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET);
 
   ecx_writestate(&self->ecx_context, 0);
 
   int attempt = 0;
   while (true) {
     int sent = ecx_send_overlap_processdata(&self->ecx_context);
-    uint64 bad_wkc_indices_val = 0;
-    uint64* bad_wkc_indices = &bad_wkc_indices_val;
-    int wkc  = ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET, bad_wkc_indices);
+    int wkc  = ecx_receive_processdata(&self->ecx_context, EC_TIMEOUTRET);
     ec_state actual_state = ecx_statecheck(
         &self->ecx_context, 0, EC_STATE_OPERATIONAL, EC_TIMEOUTSTATE);
 
@@ -280,9 +276,7 @@ void jsd_read(jsd_t* self, int timeout_us) {
   assert(self);
 
   // Wait for EtherCat frame to return from slaves, with logic for smart prints
-  uint64 bad_wkc_indices_val = 0;
-  uint64* bad_wkc_indices = &bad_wkc_indices_val;
-  self->wkc = ecx_receive_processdata(&self->ecx_context, timeout_us, bad_wkc_indices);
+  self->wkc = ecx_receive_processdata(&self->ecx_context, timeout_us);
   if (self->wkc != self->expected_wkc && self->last_wkc != self->wkc) {
     WARNING("ecx_receive_processdata returning bad wkc: %d (expected: %d)",
             self->wkc, self->expected_wkc);

--- a/src/jsd.h
+++ b/src/jsd.h
@@ -8,6 +8,7 @@ extern "C" {
 #include "jsd/jsd_pub.h"
 
 #define JSD_PO2OP_MAX_ATTEMPTS 3
+#define JSD_ELIST_MAX_READS 100
 
 /**
  * @brief converts ec_state int to human-readable string

--- a/src/jsd_pub.h
+++ b/src/jsd_pub.h
@@ -54,6 +54,13 @@ void jsd_set_slave_config(jsd_t* self, uint16_t slave_id,
 bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery);
 
 /**
+ * @brief Determines if all slaves are operational via individual slave queries
+ * 
+ * @param self pointer JSD context
+ */
+bool jsd_all_slaves_operational(jsd_t* self);
+
+/**
  * @brief After experiencing a bad working counter it is advised to check the 
  * context to discover which devices were problematic (if any).
  *

--- a/src/jsd_pub.h
+++ b/src/jsd_pub.h
@@ -54,6 +54,14 @@ void jsd_set_slave_config(jsd_t* self, uint16_t slave_id,
 bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery);
 
 /**
+ * @brief After experiencing a bad working counter it is advised to check the 
+ * context to discover which devices were problematic (if any).
+ *
+ * @param self pointer JSD context
+ */
+void jsd_inspect_context(jsd_t* self);
+
+/**
  * @brief Receive data from slave devices and store on local IOmap.
  *
  * @param self pointer JSD context


### PR DESCRIPTION
Added a function that can be called by fastcat to confirm if jsd devices are operational at time of bad working counter. This will allow one to differentiate between situations where the CPU is overloaded and if there is simply poor physical connections to a device. 

I have attached three pictures:
The first being where the entire JSD device is turned off (corresponds to poor power to the jsd bus). 
The second where a single device at the end of the bus was unplugged (corresponds to a single bad device connection).
The third being where the timeout for jsd_read was set to a very small number to force the underlying SOEM function to time out (corresponds to no faulty JSD connections).

![image](https://github.com/user-attachments/assets/d4ad4882-e465-4abf-b975-d0b5e6ef78f6)
![image](https://github.com/user-attachments/assets/41f13cc7-76b1-41d7-9db6-cb332d8241aa)
![image](https://github.com/user-attachments/assets/24b02d1d-1c0e-402a-b115-eef4e7d0b676)


TODO:
Need to update the jsd tests to avoid test failures.

