### PR TITLE
Added a short delay to ensure timely PDOs

### DIFF
--- a/src/jsd.c
+++ b/src/jsd.c
@@ -182,6 +182,9 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery, int 
       struct timespec diff;
       diff.tv_sec = current_time.tv_sec - start_processdata_time.tv_sec;
       diff.tv_nsec = current_time.tv_nsec - start_processdata_time.tv_nsec;
+      
+      // Sleep for period defined by timeout_us before attempting to do a receive_processdata.
+      // LRW packets must be sent at constant interval to encourage a successful transition to OP state/
       if (nanosleep(&diff, NULL) < 0) {
         perror("nanosleep failed");
         return 1;

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -213,8 +213,6 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
       WARNING("Failed OP transition attempt %d of %d", attempt,
               JSD_PO2OP_MAX_ATTEMPTS);
 
-      jsd_inspect_context(self);
-
       if (attempt >= JSD_PO2OP_MAX_ATTEMPTS) {
         ERROR("Max number of attempts to transition to OPERATIONAL exceeded.");
         return false;

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -191,7 +191,6 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
     clock_gettime(CLOCK_REALTIME, &start_processdata_time);
     int sent = ecx_send_overlap_processdata(&self->ecx_context);
     int wkc  = ecx_receive_processdata(&self->ecx_context, timeout_us);
-      
     ec_state actual_state = ecx_statecheck(
         &self->ecx_context, 0, EC_STATE_OPERATIONAL, EC_TIMEOUTSTATE);
 

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -83,7 +83,7 @@ void jsd_set_slave_config(jsd_t* self, uint16_t slave_id,
   self->slave_configs[slave_id] = slave_config;
 }
 
-bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
+bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery, int timeout_us) {
   assert(self);
   self->enable_autorecovery = enable_autorecovery;
 

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -175,7 +175,7 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery, int 
   while (true) {
     struct timespec current_time;
     clock_gettime(CLOCK_REALTIME, &current_time);
-    if ((start_processdata_time.tv_nsec - current_time.tv_nsec)/1e3 > timeout_us) {
+    if ((current_time.tv_nsec - start_processdata_time.tv_nsec)/1e3 > timeout_us) {
       MSG_DEBUG("Went over the loop period!");
     }
     else {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -204,7 +204,6 @@ bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery) {
       WARNING("Did not reach %s, actual state is %s",
               jsd_ec_state_to_string(EC_STATE_OPERATIONAL),
               jsd_ec_state_to_string(actual_state));
-
       if (sent <= 0) {
         WARNING("Process data could not be transmitted properly.");
       }

--- a/src/jsd_pub.h
+++ b/src/jsd_pub.h
@@ -51,7 +51,7 @@ void jsd_set_slave_config(jsd_t* self, uint16_t slave_id,
  * @param enable_autorecovery enables automatic recovery of lost devices
  * @return true on successful SOEM initialization
  */
-bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery);
+bool jsd_init(jsd_t* self, const char* ifname, uint8_t enable_autorecovery, int timeout_us);
 
 /**
  * @brief Receive data from slave devices and store on local IOmap.

--- a/test/device/jsd_minimal_example_el3602.c
+++ b/test/device/jsd_minimal_example_el3602.c
@@ -23,7 +23,7 @@ int main() {
   jsd_set_slave_config(jsd, slave_id, my_config);
 
   // Slave configuration must come before initialization
-  if (!jsd_init(jsd, "eth9", 1)) {
+  if (!jsd_init(jsd, "eth9", 1, EC_TIMEOUTRET)) {
     ERROR("Could not init jsd");
     return 0;
   }

--- a/test/jsd_test_utils.c
+++ b/test/jsd_test_utils.c
@@ -103,7 +103,7 @@ void sds_run(single_device_server_t* self, char* device_name, char* filename) {
 
   uint32_t sds_iter = 0;
 
-  if (!jsd_init(self->jsd, device_name, 1)) {
+  if (!jsd_init(self->jsd, device_name, 1, EC_TIMEOUTRET)) {
     ERROR("Could not init jsd");
     return;
   }

--- a/test/unit/jsd_soem_init_close_test.c
+++ b/test/unit/jsd_soem_init_close_test.c
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
 
   jsd_t* jsd = jsd_alloc();
 
-  if (!jsd_init(jsd, argv[1], 1)) {
+  if (!jsd_init(jsd, argv[1], 1, EC_TIMEOUTRET)) {
     ERROR("Could not init jsd");
     return 0;
   }

--- a/tools/jsd_egd_tlc_tty.c
+++ b/tools/jsd_egd_tlc_tty.c
@@ -151,7 +151,7 @@ int main(int argc, char* argv[]) {
   jsd_set_slave_config(jsd, slave_id, my_config);
 
   // slave configuration must come before initialization
-  if (!jsd_init(jsd, ifname, 1)) {
+  if (!jsd_init(jsd, ifname, 1, EC_TIMEOUTRET)) {
     ERROR("Could not init jsd");
     return 0;
   }


### PR DESCRIPTION
It was found that some devices, specifically Platinum drives, would not transition into operational state. From debugging, research, and headaches, it was found that the issue was due to non-timely sending of PDOs. When PDOs are not sent at a timely rate, the slave will not transition to Operational mode.

This information is presented here:

https://github.com/OpenEtherCATsociety/SOEM/issues/224

"Mostly a 1ms cycle time will work. When the slave sees enough LRW packets at a constant interval it will lock to that and release to Operational."