### PR TITLE
Added ecx_writestate to combat wkc faults

### DIFF
--- a/src/jsd.c
+++ b/src/jsd.c
@@ -247,7 +247,7 @@ bool jsd_all_slaves_operational(jsd_t* self) {
         ERROR("slave[%d] is in SAFE_OP + ERROR.", slave);
         self->ecx_context.slavelist[slave].state =
             (EC_STATE_SAFE_OP + EC_STATE_ACK);
-        ecx_writestate(slave);
+        ecx_writestate(&self->ecx_context, slave);
       } else if (self->ecx_context.slavelist[slave].state == EC_STATE_SAFE_OP) {
         ERROR("slave[%d] is in SAFE_OP.", slave);
       } else if (self->ecx_context.slavelist[slave].state > EC_STATE_NONE) {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -247,7 +247,7 @@ bool jsd_all_slaves_operational(jsd_t* self) {
         ERROR("slave[%d] is in SAFE_OP + ERROR.", slave);
         self->ecx_context.slavelist[slave].state =
             (EC_STATE_SAFE_OP + EC_STATE_ACK);
-        ec_writestate(slave);
+        ecx_writestate(slave);
       } else if (self->ecx_context.slavelist[slave].state == EC_STATE_SAFE_OP) {
         ERROR("slave[%d] is in SAFE_OP.", slave);
       } else if (self->ecx_context.slavelist[slave].state > EC_STATE_NONE) {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -245,6 +245,9 @@ bool jsd_all_slaves_operational(jsd_t* self) {
       if (self->ecx_context.slavelist[slave].state ==
           (EC_STATE_SAFE_OP + EC_STATE_ERROR)) {
         ERROR("slave[%d] is in SAFE_OP + ERROR.", slave);
+        self->ecx_context.slavelist[slave].state =
+            (EC_STATE_SAFE_OP + EC_STATE_ACK);
+        ec_writestate(slave);
       } else if (self->ecx_context.slavelist[slave].state == EC_STATE_SAFE_OP) {
         ERROR("slave[%d] is in SAFE_OP.", slave);
       } else if (self->ecx_context.slavelist[slave].state > EC_STATE_NONE) {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -277,7 +277,7 @@ void jsd_inspect_context(jsd_t* self) {
       MSG("We experienced an ECAT error. When this occurs, error information "
           "aught to be saved. "
           "Errors in error list displayed below:\n");
-      while (self->ecx_context.ecaterror)
+      while (self->ecx_context.elist->head != self->ecx_context.elist->tail)
         MSG("- %s\n", ecx_elist2string(&self->ecx_context));
       MSG("Went through all errors in the elist stack.\n");
     } else {

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -250,6 +250,8 @@ bool jsd_all_slaves_operational(jsd_t* self) {
         ecx_writestate(&self->ecx_context, slave);
       } else if (self->ecx_context.slavelist[slave].state == EC_STATE_SAFE_OP) {
         ERROR("slave[%d] is in SAFE_OP.", slave);
+        self->ecx_context.slavelist[slave].state = EC_STATE_OPERATIONAL;
+        ecx_writestate(&self->ecx_context, slave);
       } else if (self->ecx_context.slavelist[slave].state > EC_STATE_NONE) {
         ERROR("slave[%d] is in state with hexadecimal: %x", slave,
               self->ecx_context.slavelist[slave].state);

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -277,9 +277,9 @@ void jsd_inspect_context(jsd_t* self) {
       MSG("We experienced an ECAT error. When this occurs, error information "
           "aught to be saved. "
           "Errors in error list displayed below:\n");
-      while (self->ecx_context.elist->head != self->ecx_context.elist->tail)
-        MSG("- %s\n", ecx_elist2string(&self->ecx_context));
-      MSG("Went through all errors in the elist stack.\n");
+      // while (self->ecx_context.elist->head != self->ecx_context.elist->tail)
+      //   MSG("- %s\n", ecx_elist2string(&self->ecx_context));
+      // MSG("Went through all errors in the elist stack.\n");
     } else {
       MSG("Despite some slaves not being operational, an ECAT error was not "
           "experienced.");

--- a/src/jsd.c
+++ b/src/jsd.c
@@ -278,7 +278,7 @@ void jsd_inspect_context(jsd_t* self) {
           "aught to be saved. "
           "Errors in error list displayed below:\n");
       while (self->ecx_context.ecaterror)
-        MSG("%s\n", ecx_elist2string(&self->ecx_context));
+        MSG("- %s\n", ecx_elist2string(&self->ecx_context));
       MSG("Went through all errors in the elist stack.\n");
     } else {
       MSG("Despite some slaves not being operational, an ECAT error was not "
@@ -293,14 +293,14 @@ void jsd_read(jsd_t* self, int timeout_us) {
   // Wait for EtherCat frame to return from slaves, with logic for smart prints
   self->wkc = ecx_receive_processdata(&self->ecx_context, timeout_us);
   if (self->wkc != self->expected_wkc && self->last_wkc != self->wkc) {
-    jsd_inspect_context(self);
     WARNING("ecx_receive_processdata returning bad wkc: %d (expected: %d)",
             self->wkc, self->expected_wkc);
+    jsd_inspect_context(self);
   }
   if (self->last_wkc != self->expected_wkc && self->wkc == self->expected_wkc) {
     if (self->last_wkc != -1) {
-      jsd_inspect_context(self);
       MSG("ecx_receive_processdata is not longer reading bad wkc");
+      jsd_inspect_context(self);
     }
   }
   self->last_wkc = self->wkc;


### PR DESCRIPTION
Opening PR for discussion

This builds upon [nasa-jpl:prestonr-feature-add-wkc-driver-saves](https://github.com/nasa-jpl/jsd/tree/prestonr-feature-add-wkc-driver-saves) and adds a couple more commits
- Adds `jsd_inspect_context` to `jsd_read`, where we check for WKC faults
- Adds ecx_writestate as per https://github.com/OpenEtherCATsociety/SOEM/blob/master/doc/tutorial.txt to make transitions from
  -  SAFE_OP + ERROR --> SAFE_OP
  -  SAFE_OP --> OPERATIONAL

Upon the first transition, I usually clear my WKC fault and I am allowed to send motion commands to the actuator
